### PR TITLE
Improve monitoring information of WMAgent components

### DIFF
--- a/bin/wmcoreD
+++ b/bin/wmcoreD
@@ -35,12 +35,15 @@ __version__ = "$Revision: 1.16 $"
 __author__ = "fvlingen@caltech.edu"
 
 import getopt
-import logging
 import os
 import subprocess
 import sys
 import time
+import json
+import psutil
 
+from Utils.Utilities import extractFromXML
+from Utils.ProcFS import processStatus
 from WMCore.Agent.Daemon.Details import Details
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.WMFactory import WMFactory
@@ -177,7 +180,7 @@ def connectionTest(configFile):
         print("skipped.")
         return
 
-    (dialect, junk) = config.CoreDatabase.connectUrl.split(":", 1)
+    dialect, _ = config.CoreDatabase.connectUrl.split(":", 1)
     socket = getattr(config.CoreDatabase, "socket", None)
 
     try:
@@ -235,6 +238,15 @@ def startup(configFile):
         else:
             print('Path for daemon file does not exist!')
             sys.exit(1)
+        # write into component area process status information
+        cpath = os.path.join(compDir, "threads.json")
+        if os.path.exists(cpath):
+            os.remove(cpath)
+        cpid = extractFromXML(daemonXML, "ProcessID")
+        with open(cpath, 'w', encoding="utf-8") as istream:
+            procStatus = processStatus(cpid)
+            istream.write(json.dumps(procStatus))
+            print("Component %s started with %s threads, see %s\n" % (component, len(procStatus), cpath))
 
     return
     
@@ -274,6 +286,10 @@ def shutdown(configFile):
                 daemon.removeAndBackupDaemonFile()
             else:
                 daemon.killWithPrejudice()
+        # remove component threads.json file
+        cpath = os.path.join(compDir, "threads.json")
+        if os.path.exists(cpath):
+            os.remove(cpath)
         if doLogCleanup:
             #  //
             # // Log Cleanup
@@ -295,7 +311,7 @@ def shutdown(configFile):
             exitCode = subprocess.call(["rm", "-rf", "%s" % compDir])
             if exitCode:
                 msg = "Failed to clean up dir: %s\n" % compDir
-                msg += output
+                msg += f"with exit code {exitCode}"
                 print(msg)
 
     return
@@ -320,17 +336,61 @@ def status(configFile):
             return
         compDir = config.section_(component).componentDir
         compDir = os.path.expandvars(compDir)
-        daemonXml = os.path.join(compDir, "Daemon.xml")
-        if not os.path.exists(daemonXml):
-            print("Component:%s Not Running" % component)
-            continue
-        daemon = Details(daemonXml)
-        if not daemon.isAlive():
-            print("Component:%s Not Running" % component)
-        else:
-            print("Component:%s Running:%s" % (component, daemon['ProcessID']))
+        checkProcessThreads(component, compDir)
 
     sys.exit(0)
+
+def checkProcessThreads(component, compDir):
+    """
+    Helper function to check process and its threads for their statuses
+    :param component: component name
+    :return: prints status of the component process and its threads
+    """
+    # check if component daemon exists
+    daemonXml = os.path.join(compDir, "Daemon.xml")
+    if not os.path.exists(daemonXml):
+        print("Component:%s Not Running" % component)
+        return
+    pid = extractFromXML(daemonXML, "ProcessID")
+
+    jsonFile = os.path.join(compDir, "threads.json")
+    with open(jsonFile, "r", encoding="utf-8") as istream:
+        data = json.load(istream)
+
+    # Extract process and its threads
+    threadPids = []
+
+    for entry in data:
+        if str(entry["pid"]) == str(pid) and entry["type"] == "process":
+            continue
+        elif entry["type"] == "thread":
+            threadPids.append(entry["pid"])
+
+    # Check if process is running
+    processRunning = psutil.pid_exists(int(pid))
+
+    # Check if threads are running
+    runningThreads = []
+    orphanThreads = []
+    process = psutil.Process(int(pid))
+    for thread in process.threads():
+        if str(thread.id) == str(pid):
+            continue  # skip pid thread
+        if str(thread.id) in threadPids:
+            runningThreads.append(thread.id)
+        else:
+            orphanThreads.append(thread.id)
+
+    # Output result
+    status = "running" if processRunning else "not-running"
+    msg = f"Component:{component} {pid} {status} with threads {runningThreads}"
+    if status == "running":
+        if len(orphanThreads) > 0:
+            status = "partially-running" if processRunning else "not-running"
+            msg = f"Component:{component} {pid} {status} with threads {runningThreads}, lost {orphanThreads} threads"
+    else:
+        msg = f"Component:{component} {pid} {status}"
+    print(msg)
 
 def restart(config):
     """

--- a/src/python/Utils/ProcFS.py
+++ b/src/python/Utils/ProcFS.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+File       : ProcFS.py
+Author     : Valentin Kuznetsov <vkuznet AT gmail dot com>
+Description: This module provides function which rely on Linux proc fs
+"""
+# system modules
+import os
+
+# 3rd party modules
+try:
+    import psutil
+    usePsutil = True
+except ImportError:
+    usePsutil = False
+
+
+def processStatus(pid, method=None):
+    """
+    Return status of the given process PID along with its threads using psutil.
+    :param pid: Process ID to inspect
+    :param method: define which method to use procfs or psutil
+    :return: list of dictionaries of `{process, pid, status}` data-structure
+    """
+    if method == 'procfs' or usePsutil == False:
+        return processStatusViaProcFS(pid)
+    return processStatusViaPsutil(pid)
+
+
+def processStatusViaPsutil(pid):
+    """
+    Return status of the given process PID along with its threads using psutil.
+    :param pid: Process ID to inspect
+    :return: list of dictionaries with {process, pid, status, type}
+    """
+    statusList = []
+
+    try:
+        proc = psutil.Process(pid)
+        processName = proc.name()
+        processStatus = proc.status()
+        statusList.append({
+            "process": processName,
+            "pid": str(pid),
+            "status": processStatus,
+            "type": "process"
+        })
+
+        # Iterate over threads
+        threads = proc.threads()
+        for thread in threads:
+            if str(pid) == str(thread.id):
+                continue
+            threadId = thread.id
+            # psutil doesn't provide thread name or detailed state, so we approximate
+            statusList.append({
+                "process": f"{processName}-thread",
+                "pid": str(threadId),
+                "status": "running",  # threads are assumed running if present
+                "type": "thread"
+            })
+
+    except psutil.NoSuchProcess:
+        return [{"error": f"Process {pid} not found"}]
+    except Exception as e:
+        return [{"error": str(e)}]
+
+    return statusList
+
+
+def processStatusViaProcFS(pid):
+    """
+    Return status of given process PID along with its threads via /proc FS look-up (available on all Linux OSes)
+    :return: list of dictionaries of `{process, pid, status}` data-structure
+    """
+    statusList = []
+    procPath = f"/proc/{pid}"
+
+    if not os.path.exists(procPath):
+        return [{"error": f"Process {pid} not found"}]
+
+    try:
+        with open(f"{procPath}/status", encoding='utf-8') as f:
+            processName = ""
+            processState = ""
+            for line in f:
+                if line.startswith("Name:"):
+                    processName = line.split(":")[1].strip()
+                elif line.startswith("State:"):
+                    processState = line.split(":")[1].strip()
+            statusList.append({"process": processName, "pid": str(pid), "status": processState, "type": "process"})
+
+        taskPath = f"{procPath}/task"
+        if os.path.exists(taskPath):
+            for threadId in os.listdir(taskPath):
+                if str(threadId) == str(pid):
+                    continue
+                with open(f"{taskPath}/{threadId}/status", encoding='utf-8') as f:
+                    threadName = ""
+                    threadState = ""
+                    for line in f:
+                        if line.startswith("Name:"):
+                            threadName = line.split(":")[1].strip()
+                        elif line.startswith("State:"):
+                            threadState = line.split(":")[1].strip()
+                    statusList.append({"process": threadName, "pid": threadId, "status": threadState, "type": "thread"})
+
+    except Exception as e:
+        return [{"error": str(e)}]
+
+    return statusList

--- a/src/python/Utils/Utilities.py
+++ b/src/python/Utils/Utilities.py
@@ -11,6 +11,16 @@ import sys
 from types import ModuleType, FunctionType
 from gc import get_referents
 
+import xml.etree.ElementTree as ET
+
+def extractFromXML(xmlFile, xmlElement):
+    tree = ET.parse(xmlFile)
+    root = tree.getroot()
+    element = root.find(f".//{xmlElement}")
+    if element is not None:
+        return element.get("Value")
+    return None
+
 def lowerCmsHeaders(headers):
     """
     Lower CMS headers in provided header's dict. The WMCore Authentication

--- a/src/python/WMCore/Agent/Daemon/Details.py
+++ b/src/python/WMCore/Agent/Daemon/Details.py
@@ -21,6 +21,7 @@ from xml.dom.minidom import parse
 
 from Utils.PythonVersion import PY3
 from Utils.Utilities import encodeUnicodeToBytesConditional
+from Utils.ProcFS import processStatus
 
 
 def run(command):
@@ -85,6 +86,13 @@ class Details(dict):
         if rc != 0:
             return False
         return True
+
+    def processStatus(self):
+        """
+        Return process status along with status of all running threads
+        :return: process status, list of dictionaries of `{process, pid, status}` data-structure
+        """
+        return processStatus(self['ProcessID'])
 
     def kill(self, signal=15):
         """

--- a/test/python/Utils_t/ProcFS_t.py
+++ b/test/python/Utils_t/ProcFS_t.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""
+Unittests for ProcFS functions
+"""
+
+# system modules
+import unittest
+import os
+import time
+import threading
+
+# WMCore modules
+from Utils.ProcFS import processStatus
+
+
+def daemon(nloops=2):
+    """
+    Dummy daemon with sleep loops
+    :param: number of loops to perform, default 2
+    """
+    for _ in range(nloops):
+        time.sleep(1)
+
+
+class TestProcessStatus(unittest.TestCase):
+    """
+    TestProcessStauts unit test class
+    """
+    def testProcessStatus(self):
+        """Test processStatus function with the current process PID."""
+        pid = os.getpid()  # Get the current process ID
+        thread = threading.Thread(target=daemon, args={})  # Create a dummy thread
+        thread.start()
+        try:
+            statusList = processStatus(pid)
+
+            # Check that at least one entry exists (main process)
+            self.assertGreater(len(statusList), 0, "Status list should not be empty")
+
+            # Ensure the first entry is the main process
+            mainProcess = statusList[0]
+            self.assertEqual(mainProcess["pid"], str(pid), "Main process PID should match")
+            self.assertIn(mainProcess["status"][0], "running", "Unexpected process state")
+
+            # Ensure that we have two pids: one for main process and another for daemon thread
+            pids = [entry["pid"] for entry in statusList]
+            self.assertTrue(len(pids), 2)
+            self.assertTrue(pids[0] != pids[1], True)
+
+        finally:
+            thread.join()  # Ensure thread finishes execution
+
+    def worker(self):
+        """A simple worker thread that runs for a short time."""
+        time.sleep(2)  # Keep the thread alive for 2 seconds
+
+    def testProcessStatusWithStoppedThread(self):
+        """Test processStatus when a thread is running and then stopped."""
+        pid = os.getpid()  # Get current process ID
+        thread = threading.Thread(target=self.worker)
+        thread.start()  # Start the thread
+
+        time.sleep(0.5)  # Wait for the thread to be fully initialized
+
+        # Check status while the thread is running
+        statusList = processStatus(pid)
+        pids = [entry["pid"] for entry in statusList]
+        self.assertTrue(len(pids), 2)
+
+        # Let the thread finish (simulate stopping)
+        thread.join()
+
+        time.sleep(1)  # Allow time for the system to reflect thread termination
+
+        # Check status after thread stops
+        statusList = processStatus(pid)
+        pids = [entry["pid"] for entry in statusList]
+        self.assertTrue(len(pids), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/Utils_t/ProcessStats_t.py
+++ b/test/python/Utils_t/ProcessStats_t.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+Unittests for ProcessStats module
+"""
+
+# system modules
+import unittest
+import os
+
+# WMCore modules
+from Utils.ProcessStats import processThreadsInfo
+
+
+class TestProcessTHreadsInfo(unittest.TestCase):
+    """
+    TestProcessThreadsInfo unit test class
+    """
+    def testProcessThreadsInfo(self):
+        pid = os.getpid()  # Get current process ID
+        info = processThreadsInfo(pid)
+        self.assertTrue(info['pid'] == pid)
+        self.assertTrue(info['status'] == 'running')
+        self.assertTrue(len(info['threads']) == 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/Utils_t/Utilities_t.py
+++ b/test/python/Utils_t/Utilities_t.py
@@ -4,11 +4,14 @@ Unittests for Utilities functions
 """
 
 from builtins import object
+import os
+import tempfile
 import unittest
 
 from Utils.Utilities import makeList, makeNonEmptyList, strToBool, \
     safeStr, rootUrlJoin, zipEncodeStr, lowerCmsHeaders, getSize, \
-    encodeUnicodeToBytes, diskUse, numberCouchProcess, normalize_spaces
+    encodeUnicodeToBytes, diskUse, numberCouchProcess, normalize_spaces, \
+    extractFromXML
 
 
 class UtilitiesTests(unittest.TestCase):
@@ -235,6 +238,28 @@ cms::Exception caught in CMS.EventProcessor and rethrown
         # there should be at least one process, but who knows...
         self.assertTrue(data >= 0)
 
+    def testExtractFromXML(self):
+        """Test extracting an existing element from XML."""
+
+        # create new xmlContent file
+        xmlContent = """<?xml version="1.0"?>
+        <Daemon>
+            <ProcessID Value="1953175"/>
+            <ParentProcessID Value="1"/>
+            <ProcessGroupID Value="1953174"/>
+        </Daemon>"""
+
+        tempXML = tempfile.NamedTemporaryFile(delete=False, suffix=".xml")
+        tempXML.write(xmlContent.encode("utf-8"))
+        tempXML.close()
+
+        value = extractFromXML(tempXML.name, "ProcessID")
+        self.assertEqual(value, "1953175")
+        value = extractFromXML(tempXML.name, "NonExistingElement")
+        self.assertIsNone(value)
+
+        # remove tempXML
+        os.unlink(tempXML.name)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #12145 

#### Status
ready

#### Description
To improve WMagent component's monitoring we introduced the following changes:

- Add new procfs module with `processStatus` function based on `/proc` info for given PID. This function returns information about process threads which later can be used by WMStats. For example, here is addition to [`agentInfo`](https://cmsweb-testbed.cern.ch/couchdb/wmstats/_design/WMStats/_view/agentInfo) dictionary we supply to CouchDB:
```
  "components": {
...
    "DBS3Upload": [
      {"process": "python", "pid": "1921054", "status": "S (sleeping)",  "type": "process"},
      {"process": "python", "pid": "1921059", "status": "S (sleeping)",  "type": "thread" }
    ],
...
}
```
It shows the main process and its threads, in this case main process pid is 1921054, and pid of its threads (in this case only one additional thread) is 1921059 which is in sleeping state.

- add `processThreadsInfo` function in `Utils/ProcessStats.py` module which provides process and thread monitoring information:
```
{"process_name": .., "pid": .., "status": .., "ppid": .., "cmdline":.., 
 "cpu_usage_percent": .., "memory_usage_percent": .., "memory_rss": .., 
 "num_open_files": .., "num_connections": .., 
 "threads": [..]}
```
and thread info:
```
{"thread_id": .., "user_time":.., "system_time":.., "cpu_usage_percent": ..,
  "memory_usage_bytes":.., "num_open_files":.., "num_connections":..,
  "state":.., "name":..}
```
- update `WMComponent/AnalyticsDataCollector/DataCollectAPI.py` parts with information about dead threads via `threadsDetails` function within `agentInfo['down_component_detail']` used by WMStats web UI
- update `bin/wmcoreD` where we provide status of component's process along with its threads, e.g.
```
manage status
...
Component:WorkQueueManager 3545240 running with threads [3545241, 3545242, 3545243, 3545244]
Component:DBS3Upload 3545249 running with threads [3545254]
...
```
Each component now reports all its threads and if thread is missing/died/stuck it will provide proper message about it, e.g. component can be in `partially-running` state where its main process and some of the threads are ok but other threads misbehave

- introduced `trheads.json` file in component area along with `Daemon.xml` to capture initial conditions of component state. This information is used by aforementioned new functionality to determine if original threads are running or died

- propagate thread information into `WMComponent/AnalyticsDataCollector/DataCollectAPI.py` who use it and analyze state of specific component and properly report its state (with new threads information) to CouchDB.

**Note:** The information reported in WMStats web UI **agentInfo** tab can be accessed via the following URL: `https://xxxx.cern.ch/couchdb/wmstats/_design/WMStats/_view/agentInfo` which return nested dictionary which is used by WMStats JavaScript engine to report this information in **agentInfo** tab.

**Pylint note:** I noticed degradation in modified `bin/wmcoreD` codebase which is not related to proposed changes. For instance, there are underlined variables used in this codebase. And, I explicitly did not touch those errors/warnings which most likely come from stricter rules imposed by pylint over time. If those should be addressed I suggest to make an explicit request for them and I'll be happy to fix those issues.

**Note II:** The proposed changed to `wmcoreD` will affect output of `manage status` for list of components. In particular the new output for each individual component will have the following outputs:
- if everything is fine
```
Component:ABC 123 running with threads X
```
- if main process is dead
```
Component:ABC 123 not-running
```

- if main process is alive but one of its threads is dead
```
Component:ABC 123 partially-running with threads X, lost Y threads
```


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
