### PR TITLE
Fix location of rel_microarchs variable in SimpleCondorPlugin

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -159,7 +159,6 @@ class SimpleCondorPlugin(BasePlugin):
             return successfulJobs, failedJobs
 
         schedd = htcondor.Schedd()
-        rel_microarchs = self.tc.defaultMicroArchVersionNumberByRelease()
 
         # Submit the jobs
         for jobsReady in grouper(jobs, self.jobsPerSubmit):
@@ -504,6 +503,8 @@ class SimpleCondorPlugin(BasePlugin):
 
         undefined = 'UNDEFINED'
         jobParameters = []
+        # fetch an up-to-date list of CMSSW micro-architectures
+        rel_microarchs = self.tc.defaultMicroArchVersionNumberByRelease()
 
         for job in jobList:
             ad = {}


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12168
Complement to https://github.com/dmwm/WMCore/pull/12270

#### Status
not-tested

#### Description
Correct where `rel_microarchs` variable is defined and consumed.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Bug inserted in https://github.com/dmwm/WMCore/pull/12270

#### External dependencies / deployment changes
None