### PR TITLE
restartComponent - full path of manage script

### DIFF
--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -17,7 +17,7 @@ ALERT_EMAILS=`sed -E 's/^[[:space:]]*ALERT_EMAILS[[:space:]]*=[[:space:]]*"([^"]
 [[ -z $WMA_INSTALL_DIR ]] && { echo "ERROR: Trying to run without having the full WMAgent environment set!";  exit 1 ;}
 
 echo -e "\n###Checking agent logs at: $(date)"
-comps=$(manage execute-agent wmcoreD --status |awk '{print $1}' |awk -F \: '{print $2}')
+comps=$($WMA_DEPLOY_DIR/bin/manage execute-agent wmcoreD --status |awk '{print $1' |awk -F \: '{print $2}')
 for comp in $comps; do
   COMPLOG=$WMA_INSTALL_DIR/$comp/ComponentLog
   if [ ! -f $COMPLOG ]; then
@@ -36,7 +36,7 @@ for comp in $comps; do
 
     TAIL_LOG=$(tail -n100 $COMPLOG)
     echo -e "Restarting component: $comp"
-    manage execute-agent wmcoreD --restart --components=$comp
+    $WMA_DEPLOY_DIR/bin/manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
       mail -s "$HOST : $comp restarted" $ALERT_EMAILS
   fi


### PR DESCRIPTION
Fixes #12307 

#### Status

- [x] tested manually
- [x] tested manually with same environment of crontab 
- [x] tested from crontab

<details><summary>recent run on submit9, crontab</summary>

```plaintext
###Checking agent logs at: Mon Mar 17 10:45:01 UTC 2025
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'WMCore'
Checking logs from: /data/srv/wmagent/2.3.9/install/WorkQueueManager/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/DBS3Upload/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobAccountant/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobCreator/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobSubmitter/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobTracker/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobStatusLite/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobUpdater/ComponentLog
Restarting component: JobUpdater
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'WMCore'
execute_command_agent: Executing: wmcoreD --restart --components=JobUpdater ...

started with pid 1604528
Components List Specified:
[JobUpdater]
Checking default database connection... ok.
Stopping components: ['JobUpdater']
Stopping: JobUpdater
Starting components: ['JobUpdater']
Starting : JobUpdater
Starting JobUpdater as a daemon
Log will be in /data/srv/wmagent/2.3.9/install/JobUpdater
Waiting 1 seconds, to ensure daemon file is created
Checking logs from: /data/srv/wmagent/2.3.9/install/ErrorHandler/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/RetryManager/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/JobArchiver/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/TaskArchiver/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/AnalyticsDataCollector/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/ArchiveDataReporter/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/AgentStatusWatcher/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/RucioInjector/ComponentLog
Checking logs from: /data/srv/wmagent/2.3.9/install/WorkflowUpdater/ComponentLog
(WMAgent-2.3.9.2) [cmsdataops@cmsgwms-submit9:current]$
```

</details>

#### Description

do not assume that the `manage` script is in the cron env. refer to it using full path.

the script log complains that it does not find WMCore, but it does not seem to be a problem, it produces the correct list of components in any case. running from the same environment as crontab gives:

<details><summary> crontab environment </summary>

```plaintext
(WMAgent-2.3.9.2) [cmsdataops@cmsgwms-submit9:current]$ env - $(cat /tmp/cronenv) /bin/sh
$ bash -x /usr/local/deploy/restartComponent.sh
++ hostname
+ HOST=cmsgwms-submit9.fnal.gov
++ date +%s
+ DATENOW=1742207552
+ DEST_NAME=cms-wmcore-team
+ manage=/usr/local/bin/manage
+ [[ -z /data/srv/wmagent/2.3.9/install ]]
++ date
+ echo -e '\n###Checking agent logs at: Mon Mar 17 10:32:32 UTC 2025'
###Checking agent logs at: Mon Mar 17 10:32:32 UTC 2025
++ /usr/local/bin/manage execute-agent wmcoreD --status
++ awk '{print $1}'
++ awk -F : '{print $2}'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'WMCore'
+ comps='


WorkQueueManager
DBS3Upload
JobAccountant
JobCreator
JobSubmitter
JobTracker
JobStatusLite
JobUpdater
ErrorHandler
RetryManager
JobArchiver
TaskArchiver
AnalyticsDataCollector
ArchiveDataReporter
AgentStatusWatcher
RucioInjector
WorkflowUpdater'
[...]
```

</details>

Running manage script from the container environment

<details><summary>from container environment, docker exec, as cmsdataops</summary>

```plaintext
(WMAgent-2.3.9.2) [cmsdataops@cmsgwms-submit9:current]$ manage execute-agent wmcoreD --status |awk '{print $1}' |awk -F \: '{print $2}'



WorkQueueManager
DBS3Upload
JobAccountant
JobCreator
JobSubmitter
JobTracker
JobStatusLite
JobUpdater
ErrorHandler
RetryManager
JobArchiver
TaskArchiver
AnalyticsDataCollector
ArchiveDataReporter
AgentStatusWatcher
RucioInjector
WorkflowUpdater
(WMAgent-2.3.9.2) [cmsdataops@cmsgwms-submit9:current]$
```

</details>
#### Is it backward compatible (if not, which system it affects?)yes

#### Related PRs
none

#### External dependencies / deployment changes
none
