### PR TITLE
Properly parse and handle DBS client errors

### DIFF
--- a/src/python/WMCore/Services/DBS/DBSErrors.py
+++ b/src/python/WMCore/Services/DBS/DBSErrors.py
@@ -3,7 +3,6 @@
 DBSErrors represents generic class to handle DBS Go server errors
 """
 
-
 import json
 
 from WMCore.Services.DBS.ProdException import ProdException

--- a/src/python/WMQuality/Emulators/DBS/DBSUtils.py
+++ b/src/python/WMQuality/Emulators/DBS/DBSUtils.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+"""
+Version of DBSUtils module to be used with mock or unittest.mock
+"""
+
+
+def MockDBSErrors(dbsUrl):
+    """
+    Fetch and return all DBS server errors
+    :param dbsUrl: dbs url, we do not use it here in mock function
+    :return: dictionary of DBS server errors and their meaning
+    """
+    dbsErrors = {
+            100: 'generic DBS error',
+            101: 'database error',
+            300: 'insert error for dataset'
+            }
+    return dbsErrors

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
@@ -7,11 +7,14 @@ Unit test for the DBSUtils module
 
 import time
 import unittest
+import mock
 
 from nose.plugins.attrib import attr
 
-from WMCore.Services.DBS.DBSUtils import urlParams
+import WMCore.Services.DBS.DBSUtils
+from WMCore.Services.DBS.DBSUtils import urlParams, DBSErrors
 from WMCore.Services.DBS.DBS3Reader import DBS3Reader
+from WMQuality.Emulators.DBS.DBSUtils import MockDBSErrors
 
 
 class DBSUtilsTest(unittest.TestCase):
@@ -139,6 +142,29 @@ class DBSUtilsTest(unittest.TestCase):
         time2 = time.time() - time0
         self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
         self.assertTrue(res1 == res2)
+
+    @attr("integration")
+    def testDBSErrors(self):
+        """
+        integration test for DBSErrors function
+        """
+        url = 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader'
+        dbsErrors = DBSErrors(url)
+        self.assertTrue(100 in dbsErrors)
+        self.assertTrue(101 in dbsErrors)
+        self.assertTrue(300 in dbsErrors)
+        self.assertTrue(dbsErrors[100] == 'generic DBS error')
+
+    def testMockDBSErrors(self):
+        """
+        mock unit test for DBSErrors function
+        """
+        with mock.patch('WMCore.Services.DBS.DBSUtils.DBSErrors', new=MockDBSErrors):
+            dbsErrors = WMCore.Services.DBS.DBSUtils.DBSErrors("")  # mocked DBSErrors function
+            self.assertTrue(100 in dbsErrors)
+            self.assertTrue(101 in dbsErrors)
+            self.assertTrue(300 in dbsErrors)
+            self.assertTrue(dbsErrors[100] == 'generic DBS error')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #12229 

#### Status
ready

#### Description
Properly collect all DBS error codes and provide new method to represent them to the client. The client code can request for DBS error codes and interpret them accordingly. Adjust DBSUploadPoller to use DBS error codes and perform necessary logic to use DBS error message:
- added check for block existence before inserting it to DBS
- this eliminates hard-coded codes in DBSUploadPoller
- and generalize usage of DBSError message for reporting
- the DBSError now returns code of logic operation which we look-up from DBS errors dict, obtained from`/errors` end-point, and rely on DBS message to show DBS error flow.

#### Is it backward compatible (if not, which system it affects?)
NO, the DBS error codes were re-grouped on DBS server side to provide the following ranges:
- 1xx codes are allocated for generic errors, e.g. `DatabaseErrorCode` or `ReaderErrorCode`
- 2xx codes are allocated for logic errors, e.g. `BlockAlreadyExist` or `PrimaryDatasetDoesNotExist`
- 3xx codes are allocated for database insert operations, e.g. `InsertBlockErrorCode` or `InsertDatasetAccessTypeErrorCode`
- 4xx codes are allocated for transient errors, like missing data in DBS, e.g. `GetDataTierIDErrorCode` when we look-up foreign key for provided data tier, and if data tier is not present in DBS this error will be raised. Please note that DBS message should provide further details about which data-tier value was not present the codes themselves are not aware of specific values stored in DBS.
- 5xx codes are allocated for update, remove, clean-up operations like `UpdateBlockErrorCode` or `CancelMigrationErrorCode`

Therefore, in order to apply these changes we first need to upgrade dbs server and then can use this changes in a client.

#### Further improvements
It is possible to improve further how WM client will treat DBS error codes. For instance we can use provided ranges to improve and generalize return message. For instance, once we got DBS error code we canexplicitly say if it is insert or transient error. But new DBS error message will provide these details too.

The way how DBS errors are displayed in WM client code is shown in this https://github.com/dmwm/WMCore/pull/12312#issuecomment-2840313254

#### Related PRs
Here is complete list of DBS server related PRs to improve DBS error handling in client:
- [dmwm/dbs2go#121](https://github.com/dmwm/dbs2go/pull/121) fix parent file error code when parent of lfn is not found
- [dmwm/dbs2go#122](https://github.com/dmwm/dbs2go/pull/122) improve DBS error output (make it human readable) for nested errors
- [dmwm/dbs2go#124](https://github.com/dmwm/dbs2go/pull/124) CChange generic error codes to expilcit ones by addressing commits, looks-up and insert of different parts of bulkblock API
- [dmwm/dbs2go#129](https://github.com/dmwm/dbs2go/pull/129) New set of DBS Error codes with explicit content about all failures/errors
- [dmwm/dbs2go#130](https://github.com/dmwm/dbs2go/pull/130) add explanation of new DBS error codes
- [dmwm/dbs2go#131](https://github.com/dmwm/dbs2go/pull/131) to provide `/errors` end point and allow discovery of DBS error codes
- [dmwm/dbs2go#137](https://github.com/dmwm/dbs2go/pull/137) use explicit codes

**Examples:**
Below we provide examples of concrete DBSError and output of `/errors` end-point used to provide meaning of all DBS error codes.

Here is concrete example of failed DBS server API:
```
scurl -s "https://xxxx.cern.ch:port/dbs/int/global/DBSReader/datatiers?dataset=bla" | jq
[
  {
    "error": {
      "reason": "\nDBSError\n   Code: 118\n   Description: DBS invalid parameter for the DBS API or validation error\n   Function: dbs.validator.Check\n   Message: unable to match 'dataset' value 'bla'\n   Reason: invalid parameter(s)\n",
      "message": "not str type",
      "function": "dbs.Validate",
      "code": 113,
      "stacktrace": "\ngoroutine 91170 [running]:\ngithub.com/dmwm/dbs2go/dbs.Error({0xbd67a0?, 0xc0006a7200?}, 0x71, {0xae5205, 0xc}, {0xae5211, 0xc})\n\t/go/src/github.com/vkuznet/dbs2go/dbs/errors.go:383 +0x99\ngithub.com/dmwm/dbs2go/dbs.Validate(0xc00006e5e8?)\n\t/go/src/github.com/vkuznet/dbs2go/dbs/validator.go:337 +0x394\ngithub.com/dmwm/dbs2go/web.validateMiddleware.func1({0xbda670, 0xc000646168}, 0xc000310640)\n\t/go/src/github.com/vkuznet/dbs2go/web/middlewares.go:91 +0x7b\nnet/http.HandlerFunc.ServeHTTP(0x76925b?, {0xbda670?, 0xc000646168?}, 0x0?)\n\t/usr/local/go/src/net/http/server.go:2294 +0x29\ngithub.com/dmwm/dbs2go/web.authMiddleware.func1({0xbda670, 0xc000646168}, 0xc000310640)\n\t/go/src/github.com/vkuznet/dbs2go/web/middlewares.go:79 +0x343\nnet/http.HandlerFunc.ServeHTTP(0x10?, {0xbda670?, 0xc000646168?}, 0xc00006e848?)\n\t/usr/local/go/src/net/http/server.go:2294 +0x29\ngithub.com/vkuznet/auth-proxy-server/logging.LoggingMiddleware.func1({0xbda4d8, 0xc00055c0e0}, 0xc000310640)\n\t/go/pkg/mod/github.com/vkuznet/auth-proxy-server/lo"
    },
    "http": {
      "method": "GET",
      "code": 400,
      "timestamp": "2025-05-06 16:42:17.020682622 +0000 UTC m=+61395.357610561",
      "path": "/dbs/int/global/DBSReader/datatiers?dataset=bla",
      "user_agent": "curl/8.13.0",
      "x_forwarded_host": "xxxx.cern.ch",
      "x_forwarded_for": "xxx.xxx.xxx.xxx",
      "remote_addr": "xxx.xxx.xxx.xxx:50990"
    },
    "exception": 400,
    "type": "HTTPError",
    "message": "\nDBSError\n   Code: 113\n   Description: DBS validation error, e.g. input parameter does not match lexicon rules\n   Function: dbs.Validate\n   Message: not str type\n   Reason: \nDBSError\n   Code: 118\n   Description: DBS invalid parameter for the DBS API or validation error\n   Function: dbs.validator.Check\n   Message: unable to match 'dataset' value 'bla'\n   Reason: invalid parameter(s)\n\n"
  }
]
```
And, here is (partial) output of new `/errors` DBS end-point:
```
scurl -s "https://xxxx.cern.ch:port/dbs/int/global/DBSReader/errors" | jq |
 head
[
  {
    "code": 100,
    "meaning": "Generic DBS error"
  },
  {
    "code": 101,
    "meaning": "DBS DB error"
  },
  {
...
]
```
- `error.code` defines high level DBS error code produced by DBS server upon the error
- `error.message` defines DBS message when this `code` was happen
- `error.function` defines DBS function where this happen
- `error.reason` defines reason why this error happen (it can be recursive calls through DBS codebase up to a database but not necessary)

Also, the DBS error provides `message` at high level JSON output which includes `error.code`, followed by `error.message` and finally followed by `error.reason` as newline formatted string.

The DBS `/errors` end-point provides description (meaning) of all existing DBS error codes. Therefore, usage of `error.code` and `meaning` is sufficient to compose friendly report in a client. More verbose output can be provided via utilization all of the above information or just using `message` from DBS error JSON response.

#### External dependencies / deployment changes
