### PR TITLE
Add rucio client instances to wmagent-component-standalone

### DIFF
--- a/bin/wmagent-component-standalone
+++ b/bin/wmagent-component-standalone
@@ -23,8 +23,6 @@ import importlib
 import runpy
 import pkgutil
 import inspect
-import subprocess
-from pprint import pprint,pformat
 from distutils.sysconfig import get_python_lib
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from WMCore.Configuration import loadConfigurationFile
@@ -60,24 +58,24 @@ def createOptionParser():
                     while at the same time giving the ability to overwrite some of the component's configuration parameters
                     e.g. loglevel or provide an alternative WMA_CONFIG_FILE and/or WMA_ENV_FILE.
     """
-    optParser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
+    optparser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
                                description=helpStr,
                                epilog=exampleStr)
-    optParser.add_argument("-c", "--config", dest="wmaConfigPath", help="WMAgent configuration file.",
+    optparser.add_argument("-c", "--config", dest="wmaConfigPath", help="WMAgent configuration file.",
                            default=os.environ.get("WMA_CONFIG_FILE", None))
-    optParser.add_argument("-e", "--envfile", dest="wmaEnvFilePath", help="WMAgent environment file.",
+    optparser.add_argument("-e", "--envfile", dest="wmaEnvFilePath", help="WMAgent environment file.",
                            default=os.environ.get("WMA_ENV_FILE", None))
-    optParser.add_argument("-d", "--daemon", dest="daemon",
+    optparser.add_argument("-d", "--daemon", dest="daemon",
                            default=False, action="store_true",
                            help="The component would be run as a daemon, similar to how it is run through the standard agent manage scripts.")
-    optParser.add_argument("-p", "--component", dest="wmaComponentName",
+    optparser.add_argument("-p", "--component", dest="wmaComponentName",
                            default=None,
                            help="The component/package to be loaded.")
-    optParser.add_argument("-l", "--loglevel", dest="logLevel",
+    optparser.add_argument("-l", "--loglevel", dest="logLevel",
                            default='INFO',
                            help="The loglevel at which the component should be run,")
 
-    return optParser
+    return optparser
 
 
 def main():
@@ -137,11 +135,11 @@ if __name__ == '__main__':
         os.environ['WMA_CONFIG_FILE'] = options.wmaConfigPath
 
     wmaConfig = loadConfigurationFile(options.wmaConfigPath)
-    logger.info(f"wmaEnvFilePath: {options.wmaEnvFilePath}")
-    logger.info(f"wmaConfigPath: {options.wmaConfigPath}")
-    logger.info(f"wmaComponent: {options.wmaComponentName}")
-    logger.info(f"logLevel: {options.logLevel}")
-    logger.info(f"daemon: {options.daemon}")
+    logger.info("wmaEnvFilePath: %s", options.wmaEnvFilePath)
+    logger.info("wmaConfigPath: %s", options.wmaConfigPath)
+    logger.info("wmaComponent: %s", options.wmaComponentName)
+    logger.info("logLevel: %s", options.logLevel)
+    logger.info("daemon: %s", options.daemon)
 
     connectToDB()
 
@@ -155,7 +153,7 @@ if __name__ == '__main__':
                  auth_host=wmaConfig.RucioInjector.rucioAuthUrl,
                  account=wmaConfig.RucioInjector.rucioAccount)
 
-    logger.info(f"Creating default component objects.")
+    logger.info("Creating default component objects.")
     resourceControl = ResourceControl(config=wmaConfig)
     cric = CRIC()
     wmaComponentName = options.wmaComponentName
@@ -195,7 +193,7 @@ if __name__ == '__main__':
         modules[pkgName] = module
 
         # Emulating `from module import *`"
-        logger.info(f"Populating the namespace with all definitions from {pkgName}")
+        logger.info("Populating the namespace with all definitions from %s", pkgName)
         if "__all__" in module.__dict__:
             names = module.__dict__["__all__"]
         else:
@@ -232,7 +230,7 @@ if __name__ == '__main__':
                 classDefs[pkgName][objName]=obj
 
         for className in classDefs[pkgName]:
-            logger.info(f"{fullPkgName}:{className}")
+            logger.info("%s:%s", fullPkgName, className)
             try:
                 exec(f"{className.lower()} = {className}()")
             except TypeError:
@@ -245,14 +243,14 @@ if __name__ == '__main__':
                         logger.warning(f"We did our best to create an instance of: {pkgName}. Giving up now!")
 
     def modReload():
-        for module in modules:
-            modName = modules[module].__name__
+        for mod in modules:
+            modName = modules[mod].__name__
             modInst = sys.modules.get(modName)
             if modInst:
-                logger.info(f"Reloading module:{modName}")
+                logger.info("Reloading module: %s", modName)
                 importlib.reload(modInst)
             else:
-                logger.warning(f"Cannot find module: {modName} in sys.modules")
+                logger.warning("Cannot find module: %s in sys.modules", modName)
 
     if options.daemon:
         main()

--- a/bin/wmagent-component-standalone
+++ b/bin/wmagent-component-standalone
@@ -240,7 +240,7 @@ if __name__ == '__main__':
                     try:
                         exec(f"{className.lower()} = {className}(wmaConfig, logger=logger)")
                     except TypeError:
-                        logger.warning(f"We did our best to create an instance of: {pkgName}. Giving up now!")
+                        logger.warning("We did our best to create an instance of: %s. Giving up now!", pkgName)
 
     def modReload():
         for mod in modules:

--- a/bin/wmagent-component-standalone
+++ b/bin/wmagent-component-standalone
@@ -15,17 +15,26 @@ wmagent-component-standalone -c $WMA_CONFIG_FILE -p JobAccountant -e $WMA_ENV_FI
 
 import os
 import sys
+# NOTE: Setting the sys.dont_write_bytecode flag bellow is a precaution to avoid sabotaging
+#       the work of the %autoreload module for our default ipython setup in our agents
+sys.dont_write_bytecode = True
 import logging
 import importlib
 import runpy
 import pkgutil
 import inspect
-import sysconfig
+import subprocess
+from pprint import pprint,pformat
+from distutils.sysconfig import get_python_lib
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from WMCore.Configuration import loadConfigurationFile
 from WMCore.ResourceControl.ResourceControl import ResourceControl
+from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WMInit import connectToDB
 from Utils.FileTools import loadEnvFile
+
+from WMCore.Services.Rucio.Rucio import  Rucio
+from rucio.client import Client
 
 def createOptionParser():
     """
@@ -136,8 +145,19 @@ if __name__ == '__main__':
 
     connectToDB()
 
+    # setup Rucio client
+    # * Using the WMCore Rucio Wrapper
+    rucio = Rucio(wmaConfig.RucioInjector.rucioAccount, configDict={"logger": logger})
+
+    # * Using the upstream rucio client
+    # rcl = Client(account=wmaConfig.RucioInjector.rucioAccount)
+    rcl = Client(rucio_host=wmaConfig.RucioInjector.rucioUrl,
+                 auth_host=wmaConfig.RucioInjector.rucioAuthUrl,
+                 account=wmaConfig.RucioInjector.rucioAccount)
+
     logger.info(f"Creating default component objects.")
     resourceControl = ResourceControl(config=wmaConfig)
+    cric = CRIC()
     wmaComponentName = options.wmaComponentName
     wmaComponentModule = f"WMComponent.{wmaComponentName}"
     # wmaComponent = importlib.import_module(wmaComponentModule + "." + wmaComponentName)
@@ -147,7 +167,7 @@ if __name__ == '__main__':
     # First find all possible locations for the component source
     # NOTE: We always consider PYTHONPATH first
     pythonLibPaths = os.getenv('PYTHONPATH', '').split(':')
-    pythonLibPaths.append(sysconfig.get_path("purelib"))
+    pythonLibPaths.append(get_python_lib())
     # Normalize paths and remove empty ones
     pythonLibPaths = [x for x in pythonLibPaths if x]
     for index, libPath in enumerate(pythonLibPaths):


### PR DESCRIPTION
Fixes #11855 

#### Status
ready

#### Description
During our training session I noticed  that in the upstream version of the `wmagent-component-standalone` script the rucio client instances (both the upstream Rucio client and the WMCore wrapper) were missing.

With the current PR we are adding the line for creating those instances at script execution. The  rucio configuration is taken from the `RucioInjector` component configuration from the actual `wmagent.config`  for the agent (at the environment referred  by the variable $WMA_CONFIG_FILE).
 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
