### PR TITLE
Enlarge the set of WQE statuses for dynamic parameters edit

### DIFF
--- a/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
+++ b/src/python/WMCore/ReqMgr/DataStructs/RequestStatus.py
@@ -132,7 +132,7 @@ ALLOWED_ACTIONS_FOR_STATUS = {
     "staged": ["RequestPriority"],
     "acquired": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
     "running-open": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
-    "running-closed": ["RequestPriority"],
+    "running-closed": ["RequestPriority", "SiteWhitelist", "SiteBlacklist"],
     "failed": [],
     "force-complete": [],
     "completed": [],

--- a/src/python/WMCore/ReqMgr/Service/Request.py
+++ b/src/python/WMCore/ReqMgr/Service/Request.py
@@ -432,7 +432,7 @@ class Request(RESTEntity):
 
         try:
             # Commit all Global WorkQueue changes per workflow in a single go:
-            self.gq_service.updateElementsByWorkflow(workload, reqArgs, status=['Available', 'Negotiating', 'Acquired'])
+            self.gq_service.updateElementsByWorkflow(workload, reqArgs, status=['Available', 'Negotiating', 'Acquired', 'Running'])
         except WMWorkloadUnhandledException as ex:
             # Handling assignment-approved arguments differently to avoid code duplication
             if reqStatus == 'assignment-approved':


### PR DESCRIPTION
Fixes #12326

#### Status
not-tested

#### Description
This is just a quick fix, just to prove right or wrong the stament that we still have not lost control over this system parameter. Meaning if we still have a knob to turn so taht we can restore the previous system behavior, where we were  editing down to the condor job priority. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None