### PR TITLE
Performance improvements for Global WorkQueue data location update

### DIFF
--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -182,8 +182,15 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         super(WorkQueueDataLocationMapper, self).__init__(logger, **kwargs)
 
     def __call__(self):
-        dataItems = self.backend.getActiveData()
+        outcomeStatus = ""
+        outcomeStatus += self.updatePrimaryLocation()
+        outcomeStatus += self.updateParentLocation()
+        outcomeStatus += self.updatePileupLocation()
 
+        return outcomeStatus
+
+    def updatePrimaryLocation(self):
+        dataItems = self.backend.getActiveData()
         dataLocations = super(WorkQueueDataLocationMapper, self).__call__(dataItems)
         self.logger.info("Found %d unique input data to update location", len(dataItems))
 
@@ -202,10 +209,7 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Input location update", len(modified))
         self.backend.saveElements(*modified)
 
-        numParents = self.updateParentLocation()
-        numPileups = self.updatePileupLocation()
-
-        return len(modified) + numParents + numPileups
+        return f"Updated {len(modified)} elements for primary location update.\n"
 
     def updateParentLocation(self):
         dataItems = self.backend.getActiveParentData()
@@ -235,7 +239,7 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Parent location update", len(modified))
         self.backend.saveElements(*listvalues(modified))
 
-        return len(modified)
+        return f"Updated {len(modified)} elements for parent location update.\n"
 
     def updatePileupLocation(self):
         dataItems = self.backend.getActivePileupData()
@@ -266,4 +270,4 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Pileup location update", len(modified))
         self.backend.saveElements(*listvalues(modified))
 
-        return len(modified)
+        return f"Updated {len(modified)} elements for Pileup location update."

--- a/src/python/WMCore/WorkQueue/DataLocationMapper.py
+++ b/src/python/WMCore/WorkQueue/DataLocationMapper.py
@@ -182,12 +182,12 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         super(WorkQueueDataLocationMapper, self).__init__(logger, **kwargs)
 
     def __call__(self):
-        outcomeStatus = ""
-        outcomeStatus += self.updatePrimaryLocation()
-        outcomeStatus += self.updateParentLocation()
-        outcomeStatus += self.updatePileupLocation()
+        elemUpdated = 0
+        elemUpdated += self.updatePrimaryLocation()
+        elemUpdated += self.updateParentLocation()
+        elemUpdated += self.updatePileupLocation()
 
-        return outcomeStatus
+        return elemUpdated
 
     def updatePrimaryLocation(self):
         dataItems = self.backend.getActiveData()
@@ -209,7 +209,7 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Input location update", len(modified))
         self.backend.saveElements(*modified)
 
-        return f"Updated {len(modified)} elements for primary location update.\n"
+        return len(modified)
 
     def updateParentLocation(self):
         dataItems = self.backend.getActiveParentData()
@@ -239,7 +239,7 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Parent location update", len(modified))
         self.backend.saveElements(*listvalues(modified))
 
-        return f"Updated {len(modified)} elements for parent location update.\n"
+        return len(modified)
 
     def updatePileupLocation(self):
         dataItems = self.backend.getActivePileupData()
@@ -270,4 +270,4 @@ class WorkQueueDataLocationMapper(DataLocationMapper):
         self.logger.info("Updating %d elements for Pileup location update", len(modified))
         self.backend.saveElements(*listvalues(modified))
 
-        return f"Updated {len(modified)} elements for Pileup location update."
+        return len(modified)

--- a/src/python/WMCore/WorkQueue/WorkQueueBackend.py
+++ b/src/python/WMCore/WorkQueue/WorkQueueBackend.py
@@ -567,21 +567,30 @@ class WorkQueueBackend(object):
 
     def getActiveData(self):
         """Get data items we have work in the queue for"""
-        data = self.db.loadView('WorkQueue', 'activeData', {'reduce': True, 'group': True})
-        return [{'dbs_url': x['key'][0],
-                 'name': x['key'][1]} for x in data.get('rows', [])]
+        data = self.db.loadView('WorkQueue', 'activeData', {'reduce': False, 'group': False})
+        unique_data = set()
+        for row in data.get('rows', []):
+            unique_data.add((row['key'][0], row['key'][1]))
+        return [{'dbs_url': x[0], 'name': x[1]} for x in unique_data]
 
     def getActiveParentData(self):
         """Get data items we have work in the queue for with parent"""
-        data = self.db.loadView('WorkQueue', 'activeParentData', {'reduce': True, 'group': True})
-        return [{'dbs_url': x['key'][0],
-                 'name': x['key'][1]} for x in data.get('rows', [])]
+        data = self.db.loadView('WorkQueue', 'activeParentData', {'reduce': False, 'group': False})
+        unique_data = set()
+        for row in data.get('rows', []):
+            unique_data.add((row['key'][0], row['key'][1]))
+        return [{'dbs_url': x[0], 'name': x[1]} for x in unique_data]
 
     def getActivePileupData(self):
         """Get data items we have work in the queue for with pileup"""
-        data = self.db.loadView('WorkQueue', 'activePileupData', {'reduce': True, 'group': True})
-        return [{'dbs_url': x['key'][0],
-                 'name': x['key'][1]} for x in data.get('rows', [])]
+        # Due to performance issues, we are stopping the use of reduce and group parameters for this view
+        # Further details: https://github.com/dmwm/WMCore/issues/12319
+        data = self.db.loadView('WorkQueue', 'activePileupData', {'reduce': False, 'group': False})
+
+        unique_data = set()
+        for row in data.get('rows', []):
+            unique_data.add((row['key'][0], row['key'][1]))
+        return [{'dbs_url': x[0], 'name': x[1]} for x in unique_data]
 
     def getElementsForData(self, data):
         """Get active elements for this dbs & data combo"""


### PR DESCRIPTION
Fixes #12319 

#### Status
ready

#### Description
With this pull request, we stop setting the `reduce` and `group` CouchDB view functions for:
* primary data
* parent data
* pileup data
location update, performed by the `locationUpdateTask` global workqueue central service.

This means the view returns non-unique items, but as shown in the ticket, the networking overhead is pretty small (10-20%) while the latency is orders of magnitude better.

The needed changes have been made in the code to keep the same behavior, hence loading a unique list of data items in global workqueue.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
