### PR TITLE
Get rid of  globaltagTransaction/transactionId

### DIFF
--- a/src/python/PSetTweaks/WMTweak.py
+++ b/src/python/PSetTweaks/WMTweak.py
@@ -394,8 +394,6 @@ def makeTaskTweak(stepSection, result):
                 args = pickle.loads(pklArgs)
                 if 'globalTag' in args:
                     result.addParameter("process.GlobalTag.globaltag",  "customTypeCms.string('%s')" % args['globalTag'])
-                if 'globalTagTransaction' in args:
-                    result.addParameter("process.GlobalTag.DBParameters.transactionId",  "customTypeCms.untracked.string('%s')" % args['globalTagTransaction'])
 
     return
 

--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -74,7 +74,6 @@ class ExpressWorkloadFactory(StdBase):
             expressRecoStepName = "cmsRun1"
 
             scenarioArgs = {'globalTag': self.globalTag,
-                            'globalTagTransaction': self.globalTagTransaction,
                             'skims': self.alcaSkims,
                             'dqmSeq': self.dqmSequences,
                             'outputs': self.outputs,
@@ -135,7 +134,6 @@ class ExpressWorkloadFactory(StdBase):
 
             scenarioFunc = "expressProcessing"
             scenarioArgs = {'globalTag': self.globalTag,
-                            'globalTagTransaction': self.globalTagTransaction,
                             'skims': self.alcaSkims,
                             'dqmSeq': self.dqmSequences,
                             'outputs': self.outputs,
@@ -189,7 +187,6 @@ class ExpressWorkloadFactory(StdBase):
                                 'EventStreams': 0}
 
                 scenarioArgs = {'globalTag': self.globalTag,
-                                'globalTagTransaction': self.globalTagTransaction,
                                 'skims': self.alcaSkims,
                                 'primaryDataset': self.specialDataset}
 
@@ -477,7 +474,6 @@ class ExpressWorkloadFactory(StdBase):
                     "RecoScramArch": {"validate": lambda x: all([y in architectures() for y in x]),
                                       "optional": False, "type": makeNonEmptyList},
                     "GlobalTag": {"optional": False},
-                    "GlobalTagTransaction": {"optional": False},
                     "ProcessingString": {"default": "", "validate": procstringT0},
                     "StreamName": {"optional": False},
                     "SpecialDataset": {"optional": False},

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -33,7 +33,6 @@ REQUEST = {
     "DQMUploadProxy": "/somepath/proxy",
     "DQMUploadUrl": "https://cmsweb.cern.ch/dqm/offline",
     "GlobalTag": "SomeGlobalTag",
-    "GlobalTagTransaction": "Express_123456",
     "GlobalTagConnect": "frontier://PromptProd/CMS_CONDITIONS",
     "MaxInputRate": 23 * 1000,
     "MaxInputEvents": 400,


### PR DESCRIPTION
Fixes #12320

#### Status
ready to be reviewed

#### Description
Get rid of  globaltagTransaction /transactionId from the configuration, since this feature has been deprecated 9 years ago.

#### Is it backward compatible (if not, which system it affects?)
YES
