### PR TITLE
Avoid executing archival pipeline for workflows not ready yet

### DIFF
--- a/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
+++ b/src/python/WMCore/MicroService/MSRuleCleaner/MSRuleCleaner.py
@@ -311,11 +311,8 @@ class MSRuleCleaner(MSCore):
             self.logger.info(msg)
             self._checkStatusAdvanceExpired(wflow, additionalInfo=msg)
         elif wflow['RequestStatus'] == 'announced' and not wflow['TransferTape']:
-            # NOTE: We skip workflows which have not yet finalised their tape transfers.
-            #       (i.e. even if a single output which is supposed to be covered
-            #       by a tape rule is in any of the following transient states:
-            #       {REPLICATING, STUCK, SUSPENDED, WAITING_APPROVAL}.)
-            #       We still need some proper logging for them.
+            # Given that we are still waiting for the tape transfers to be fulfilled,
+            # we can go ahead and start cleaning up the input data.
             msg = "Skipping workflow: %s - tape transfers are not yet completed." % wflow['RequestName']
             msg += "Workflow in 'announced' state, hence proceeding only with MSTransferor / input data removal. "  
             msg += "Will retry the remaining in the next cycle."
@@ -331,8 +328,10 @@ class MSRuleCleaner(MSCore):
                     msg += "\nWill retry again in the next cycle."
                     self.logger.exception(msg)
                     continue
-            
+            # return now to avoid exeecuting the archival pipeline
+            return
         elif wflow['RequestStatus'] in ['announced', 'rejected', 'aborted-completed']:
+            # Workflows reaching this block are ready for the full pipeline execution
             for pline in self.cleanuplines:
                 try:
                     pline.run(wflow)


### PR DESCRIPTION
Fixes #12328 

#### Status
ready

#### Description
For workflows that are `announced` but have not yet created all the output rules (disk and tape), skip those from the archival pipeline execution.

UPDATE: we could skip it for workflows with `TransferDone=False`, but then it fails down the stream when performing the `self._checkClean(wflow)` check in the `_execute()` method, as `PlineMarkers=None`.
 
#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Bug-fix for this PR: https://github.com/dmwm/WMCore/pull/12329

#### External dependencies / deployment changes
None