### PR TITLE
python 3.12 - necessary requirements.txt upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,14 +12,14 @@
 # for more details please refer to official Python documentation, see
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
-Cheetah3~=3.2.6.post1         # wmcore,wmagent,reqmgr2,reqmon
+CT3~=3.4.0                    # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=18.8.0              # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 CMSCouchapp~=1.3.4            # wmcore,wmagent
 CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagentdev
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client==4.0.19           # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msoutput,mstransferor
-future~=0.18.2                # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
+future~=1.0.0                 # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,msunmerged
 httplib2~=0.20.4              # wmcore,wmagent,reqmgr2,reqmon,acdcserver,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 htcondor~=24.0.7              # wmcore,wmagent
@@ -36,7 +36,7 @@ pycurl~=7.45.4                # wmcore,wmagent,reqmgr2,reqmon,wmglobalqueue,msun
 pylint~=2.14.5                # wmcore,wmagentdev
 pymongo~=4.2.0                # wmcore,wmagentdev,msunmerged,msoutput,mspileup
 pyOpenSSL~=25.0.0             # wmcore,wmagent
-pyzmq~=23.2.1                 # wmcore,wmagent
+pyzmq~=26.3.0                 # wmcore,wmagent
 retry~=0.9.2                  # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 rucio-clients~=1.29.10        # wmcore,wmagent,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 Sphinx~=5.1.1                 # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue


### PR DESCRIPTION
Related to #12208 

#### Status

tested, works on a manual docker image build with python 3.12 on debian 12

#### Description

some of the versions of the packages that we depend on are not compatible with recent python 3.12. We need to upgrade their versions if we want to be able to run with python 3.12

please, notice how the cheetah3 project changed the name of the package on pypi from `` to `CT3` [1]

#### Is it backward compatible (if not, which system it affects?)

yes, these versions are compatible with python 3.8

#### Related PRs

none

#### External dependencies / deployment changes

yes, this PR changes the versions of some packages that we depend on

---

[1]

- https://github.com/CheetahTemplate3/cheetah3 look at the readme
- https://pypi.org/project/Cheetah3/ does not receive updates anymore
- https://cheetahtemplate.org/news.html#id5 the motivation for the change is described here