### PR TITLE
python 3.12 - do not use codecs

### DIFF
--- a/src/python/WMCore/WMLogging.py
+++ b/src/python/WMCore/WMLogging.py
@@ -5,7 +5,6 @@ _WMLogging_
 Logging facilities used in WMCore.
 """
 import logging
-import codecs
 from datetime import date, timedelta
 from logging.handlers import HTTPHandler, RotatingFileHandler, TimedRotatingFileHandler
 
@@ -78,10 +77,7 @@ class MyTimedRotatingFileHandler(TimedRotatingFileHandler):
         yesterdayStr = (date.today() - timedelta(1)).strftime("%Y%m%d")
         todayStr = date.today().strftime("%Y%m%d")
         self.baseFilename = self.baseFilename.replace(yesterdayStr, todayStr)
-        if self.encoding:
-            self.stream = codecs.open(self.baseFilename, 'w', self.encoding)
-        else:
-            self.stream = open(self.baseFilename, 'w')
+        self.stream = open(self.baseFilename, 'w', encoding='utf-8')
         self.rolloverAt = self.rolloverAt + self.interval
 
 


### PR DESCRIPTION
related to #12208 

#### Status

tested in test11, this error is no longer present in the logs

#### Description

looking at the logs from central services running on python 3.12 i found multiple instances of this error [1]. the error has been found and described [2]. Since i do not think we really need to support multiple log file encodings, i think we can just deprecate the use of the `codecs` module and use a simple file `open()`

#### Is it backward compatible (if not, which system it affects?)

yes

#### Related PRs

none

#### External dependencies / deployment changes

none

---

[1]

```plaintext
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/logging/handlers.py", line 74, in emit
    self.doRollover()
  File "/usr/local/lib/python3.12/site-packages/WMCore/WMLogging.py", line 82, in doRollover
    self.stream = codecs.open(self.baseFilename, 'w', self.encoding)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 923, in open
LookupError: unknown encoding: locale

```

[2] https://github.com/python/cpython/issues/120406