### PR TITLE
Split patch files by source files edited && Apply them separately

### DIFF
--- a/bin/patchComponent.sh
+++ b/bin/patchComponent.sh
@@ -24,7 +24,9 @@ usage()
     echo -e "       curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/11270.patch | sudo ./patchComponent.sh \n"
 }
 
-
+# Add default WMCore repository links
+WMPatchUrl="https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull"
+WMRawUrl="https://raw.githubusercontent.com/dmwm/WMCore"
 
 # Add default value for zeroOnly option
 zeroOnly=false
@@ -87,41 +89,149 @@ do
     [[ -d $path/WMCore ]] && { pythonLibPath=$path; echo "INFO: Source code found at: $path"; break ;}
 done
 
+
 [[ -z $pythonLibPath  ]] && { echo "ERROR: Could not find WMCore source to patch"; exit  1 ;}
 echo "INFO: Current PythonLibPath: $pythonLibPath"
 echo --------------------------------------------------------
 echo
 
-# Set patch command parameters
-stripLevel=3
-patchCmd="patch -t --verbose -b --version-control=numbered -d $pythonLibPath -p$stripLevel"
+# Figure out if we are running from source
+runFromSource=false
+[[ $pythonLibPath =~ .*srv/WMCore/src/python ]] && runFromSource=true
 
-# Define Auxiliary functions
-_createTestFilesDst() {
-    # A simple function to create test files destination for not breaking the patches
+# Find the toplevel for the current deployment:
+$runFromSource && toplevel=`realpath $pythonLibPath/../../../../` || toplevel=`realpath $pythonLibPath/../../../`
+
+
+# Define all auxiliary functions:
+
+_patchSingle() {
+    # Auxiliary function to apply a patch file containing a single source file change
+    # The patch command parameters like stripLevel and destination are supposed
+    # to be correctly estimated based on the source file in the patch and the WMCore
+    # runtime environment (e.g. WMCore@K8 or WMAgent@Docker or WMAgent@Venv)
+    # :param $1: The path to the patch file to be applied
+    local patchFile=$1
+    local stripLevel=""
+    local dest=""
+    local patchcmd=""
+
+    # Find the source file to which the current patchFile relates
+    local srcFile=`grep -m 1 ^diff $patchFile |awk '{print $3}'`
+    srcFile=${srcFile#a\/} && srcFile=${srcFile#b\/}
+    echo INFO: $FUNCNAME: patchFile: $patchFile srcFile: $srcFile
+
+    # Set patch command parameters
+
+    # Search if the srcFile is contained in the $toplevFileList
+    [[ $toplevFileList =~ $srcFile ]] && {
+        echo INFO: $FUNCNAME: Found $BASH_REMATCH in the toplevFileList
+        stripLevel=1
+        dest=$toplevel
+    }
+
+    # Search if the srcFile is contained in the $staticFileList
+    [[ $staticFileList =~ $srcFile ]] && {
+        echo INFO: $FUNCNAME: Found $BASH_REMATCH in the staticFileList
+        stripLevel=2
+        dest=$toplevel/data
+    }
+
+    # Search if the srcFile is contained in the $testFileList
+    [[ $testFileList =~ $srcFile ]] && {
+        echo INFO: $FUNCNAME: Found $BASH_REMATCH in the testFileList
+        stripLevel=1
+        dest=$toplevel
+    }
+
+    # Search if the srcFile is contained in the $srcFileList
+    [[ $srcFileList =~ $srcFile ]] && {
+        echo INFO: $FUNCNAME: Found $BASH_REMATCH in the srcFileList
+        stripLevel=3
+        dest=$pythonLibPath
+    }
+
+    # Forge patchCmd:
+    # patchCmd="patch -t --verbose -b --version-control=numbered -d $pythonLibPath -p$stripLevel"
+    patchCmd="patch -t --verbose -b --version-control=numbered -d $dest -p$stripLevel"
+    echo "INFO: $FUNCNAME: cat $patchFile | $patchCmd"
+
+    # Apply the patch:
+    # NOTE: This must be the last line to execute in order to properly return
+    #       the error code from the attempted patch
+    cat $patchFile | $patchCmd
+}
+
+_splitPatchByFiles() {
+    # Auxiliary function to split a patch file by different files modified in the patch
+    # creating one patch file per file change in the code
+    # :param $1:  The path to the patch file to be split
+    # NOTE:       The output are to be files named as <patchFileName_[0-9][0-9].patch>
+    #             and will be placed at /tmp/patchFileName.d/
+    # NOTE:       It echos only the splitDir so that the destination of the split files
+    #             can be caught by the caller with the constrict:
+    #             `local splitDir=$(_splitPatchByfiles $patchFile)`
+    #             The return code, though, would still be the return code of the call to `csplit`
+    local patchFile=$1
+    local patchFileName=`basename $patchFile` && patchFileName=${patchFileName%.patch}
+    local splitDir=/tmp/${patchFileName}.d && echo $splitDir
+    mkdir -p $splitDir > /dev/null 2>&1
+    cd $splitDir && rm -rf *.patch > /dev/null 2>&1
+
+    # NOTE: This must be the last line to execute in order to properly return
+    #       the error code from the attempted to split the patchFile
+    csplit --quiet -b %02d.patch -z -f ${patchFileName}_ $patchFile /^diff\ --git.*/ '{*}'
+}
+
+_cleanSplitDir() {
+    # Auxiliary function to clean the splitDir from any garbage patch files created during the
+    # process of splitting the original patch file in chinks. It is possible few of the so
+    # created chunk patch files to contain only commit information  and no source code changes.
+    # These will later generate false positives during the process of incremental changes application.
+    # :param $1: The directory containing the chunk patchFiles
+    local splitDir=$1
+    for file in ${splitDir}/*
+    do
+        grep -qE ^diff $file || rm $file
+    done
+}
+
+_createFilesDst() {
+    # A simple function to create test, static and toplevel files destination for not breaking the patches
     # because of a missing destination:
     # :param $1:   The source branch to be used for checking the files: could be TAG or Master
     # :param $2-*: The list of files to be checked out
+    # NOTE:        The destinations are all starting from $toplevel but static files should
+    #              live under $toplevel/data instead of $toplevel/src
     local srcBranch=$1
     shift
-    local testFileList=$*
-    for file in $testFileList
+    local fileList=$*
+
+    for file in $fileList
     do
-        # file=${file#a\/test\/python\/}
         fileName=`basename $file`
         fileDir=`dirname $file`
+        fileDest=$toplevel/$file
+        # for static files substitute `/src/` with `/data/`
+        fileDest=${fileDest/\/src\//\/data\/}
+
+        # echo DEBUG: $FUNCNAME: fileName=$fileName
+        # echo DEBUG: $FUNCNAME: fileDir=$fileDir
+
         # Create the file path if missing
-        mkdir -p $pythonLibPath/$fileDir
-        echo INFO: orig: https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/test/python/$file
-        echo INFO: dest: $pythonLibPath/$file
-        curl -f https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/test/python/$file  -o $pythonLibPath/$file || {
-            echo INFO: file: $file missing at the origin.
-            echo INFO: Seems to be a new file for the curren patch.
-            echo INFO: Removing it from the destination as well!
-            rm -f $pythonLibPath/$file
+        # echo DEBUG: $FUNCNAME: mkdir -p $toplevel/$fileDir
+        mkdir -p $toplevel/$fileDir
+        echo INFO: $FUNCNAME: orig: $WMRawUrl/$srcBranch/$file
+        echo INFO: $FUNCNAME: dest: $fileDest
+        curl -f $WMRawUrl/$srcBranch/$file  -o $fileDest || {
+            echo INFO: $FUNCNAME: file: $file missing at the origin.
+            echo INFO: $FUNCNAME: Seems to be a new file for the curren patch.
+            echo INFO: $FUNCNAME: Removing it from the destination as well!
+            rm -f $fileDest
         }
     done
 }
+
 
 _zeroCodeBase() {
     # A simple function to zero the code base for a set of files starting from
@@ -138,12 +248,12 @@ _zeroCodeBase() {
         fileDir=`dirname $file`
         # Create the file path if missing
         mkdir -p $pythonLibPath/$fileDir
-        echo INFO: orig: https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/src/python/$file
-        echo INFO: dest: $pythonLibPath/$file
-        curl -f https://raw.githubusercontent.com/dmwm/WMCore/$srcBranch/src/python/$file  -o $pythonLibPath/$file || {
-            echo INFO: file: $file missing at the origin.
-            echo INFO: Seems to be a new file for the curren patch.
-            echo INFO: Removing it from the destination as well!
+        echo INFO: $FUNCNAME: orig: $WMRawUrl/$srcBranch/$file
+        echo INFO: $FUNCNAME: dest: $pythonLibPath/$file
+        curl -f $WMRawUrl/$srcBranch/$file  -o $pythonLibPath/$file || {
+            echo INFO: $FUNCNAME: file: $file missing at the origin.
+            echo INFO: $FUNCNAME: Seems to be a new file for the curren patch.
+            echo INFO: $FUNCNAME: Removing it from the destination as well!
             rm -f $pythonLibPath/$file
         }
     done
@@ -157,46 +267,73 @@ _zeroCodeBase() {
 patchFileList=""
 _createPatchFiles(){
     local patchFile
-
+    local splitDir
     # Check if we are running from a pipe
     $pipe && {
         if $zeroOnly ;then
-            echo "INFO: Zeroing WMCore code base from StdIn"
+            echo "INFO: $FUNCNAME: Zeroing WMCore code base from StdIn"
         else
-            echo "INFO: Patching WMCore code from StdIn"
+            echo "INFO: $FUNCNAME: Patching WMCore code from StdIn"
         fi
         patchFile="/tmp/pipeTmp_$(id -u).patch"
-        patchFileList=$patchFile
-        echo "INFO: Creating a temporary patchFile from stdin at: $patchFile"
-        cat <&0 > $patchFile
+        echo "INFO: $FUNCNAME: Creating a temporary patchFile from stdin at: $patchFile"
+        cat <&0 > $patchFile || { err=$?; echo "ERROR: $FUNCNAME: While creating $patchFile"; exit $err ;}
+        echo "INFO: $FUNCNAME: Splitting the temporary patchFile by files to update"
+        splitDir=$(_splitPatchByFiles $patchFile) || { err=$?; echo "ERROR: $FUNCNAME: While splitting $patchFile"; exit $err ;}
+
+        # Clean patchFiles containing only commit info and no source code changes:
+        _cleanSplitDir $splitDir
+
+        # Create the final list of patches
+        [[ -z `ls -A $splitDir` ]] && { echo;echo "WARNING: $FUNCNAME: Splitting $patchFile produced no output! Skipping it!!" ;}
+        patchFileList=`ls -1Xd $splitDir/*.patch`
         return
     }
 
     # Check if we were sent a file to patch from
     [[ -n $extPatchFile ]] && {
         if $zeroOnly ;then
-            echo "INFO: Zeroing WMCore code base with file: $extPatchFile"
+            echo "INFO: $FUNCNAME: Zeroing WMCore code base with file: $extPatchFile"
         else
-            echo "INFO: Patching WMCore code with file: $extPatchFile"
+            echo "INFO: $FUNCNAME: Patching WMCore code with file: $extPatchFile"
         fi
         patchFile=$extPatchFile
         patchFileList=$patchFile
-        echo "INFO: Using command line provided patch file: $patchFile"
+        echo "INFO: $FUNCNAME: Using command line provided patch file: $patchFile"
+        echo "INFO: $FUNCNAME: Splitting the command line provided patchFile by files to update"
+        splitDir=$(_splitPatchByFiles $patchFile) || { err=$?; echo "ERROR: $FUNCNAME: While splitting $patchFile"; exit $err ;}
+
+        # Clean patchFiles containing only commit info and no source code changes:
+        _cleanSplitDir $splitDir
+
+        # Create the final list of patches
+        [[ -z `ls -A $splitDir` ]] && { echo;echo "WARNING: $FUNCNAME: Splitting $patchFile produced no output! Skipping it!!" ;}
+        patchFileList=`ls -1Xd $splitDir/*.patch`
         return
     }
 
     # Finally, if none of the above, build the list of patch files to be applied from the patchNums provided at the command line
     if $zeroOnly ; then
-        echo "INFO: Zeroing WMCore code base with PRs: $patchList"
+        echo "INFO: $FUNCNAME: Zeroing WMCore code base with PRs: $patchList"
     else
-        echo "INFO: Patching WMCore code with PRs: $patchList"
+        echo "INFO: $FUNCNAME: Patching WMCore code with PRs: $patchList"
     fi
     for patchNum in $patchList
     do
         patchFile=/tmp/$patchNum.patch
-        patchFileList="$patchFileList $patchFile"
-        echo "INFO: Downloading a temporary patchFile at: $patchFile"
-        curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/$patchNum.patch -o $patchFile
+        echo "INFO: $FUNCNAME: Downloading a temporary patchFile at: $patchFile"
+        curl $WMPatchUrl/$patchNum.patch -o $patchFile || {
+            err=$?; echo "ERROR: $FUNCNAME: While downloading $patchFile"; exit $err
+        }
+        echo "INFO: $FUNCNAME: Splitting the temporary patchFile by files to update"
+        splitDir=$(_splitPatchByFiles $patchFile) || { err=$?; echo "ERROR: $FUNCNAME: While splitting $patchFile"; exit $err ;}
+
+        # Clean patchFiles containing only commit info and no source code changes:
+        _cleanSplitDir $splitDir
+
+        # Create the final list of patches
+        [[ -z `ls -A $splitDir` ]] && { echo;echo "WARNING: $FUNCNAME: Splitting $patchFile produced no output! Skipping it!!"; continue ;}
+        patchFileList="$patchFileList `ls -1Xd $splitDir/*.patch`"
     done
 }
 
@@ -208,31 +345,78 @@ _warnFilelist(){
     done
 }
 
+_sortListUniq() {
+    local list=($*)
+    local uniqList=($(printf "%s\n" "${list[@]}" | sort -u))
+    echo ${uniqList[@]}
+}
+
+
+# Start execution:
+
 _createPatchFiles
 
-echo "DEBUG: patchFileList: $patchFileList"
+echo
+echo -e "DEBUG: patchFileList: \n`for i in $patchFileList; do echo $i; done`"
+echo
 
-# Build full lists of files altered by the given set of patch files to be applied
+# Build the full lists of source files altered by the given set of patch files to be applied
 srcFileList=""
 testFileList=""
+toplevFileList=""
+staticFileList=""
 for patchFile in $patchFileList
 do
     # Parse a list of files changed only by the current patch
-    srcFileListTemp=`grep diff $patchFile |grep "a/src/python" |awk '{print $3}' |sort |uniq`
-    testFileListTemp=`grep diff $patchFile |grep "a/test/python" |awk '{print $3}' |sort |uniq`
+    srcFileListTemp=`grep ^diff $patchFile |grep "a/src/python" |awk '{print $3}' |sort -u`
+    testFileListTemp=`grep ^diff $patchFile |grep "a/test" |awk '{print $3}' |sort -u`
+    toplevFileListTemp=`grep ^diff $patchFile |grep -E "a/(bin|deploy|doc|etc|standards|tools)" |awk '{print $3}' |sort -u`
+    staticFileListTemp=`grep ^diff $patchFile |grep "a/src" |grep -v "a/src/python" |awk '{print $3}' |sort -u`
 
     # Reduce paths for both src and test file lists to the path depth known to
     # the WMCore modules/packages and add them to the global scope file lists
     for file in $srcFileListTemp
     do
-        file=${file#a\/src\/python\/} && srcFileList="$srcFileList $file"
+        file=${file#a\/} && srcFileList="$srcFileList $file"
     done
 
     for file in $testFileListTemp
     do
-        file=${file#a\/test\/python\/} && testFileList="$testFileList $file"
+        file=${file#a\/} && testFileList="$testFileList $file"
     done
+
+    for file in $toplevFileListTemp
+    do
+        file=${file#a\/} && toplevFileList="$toplevFileList $file"
+    done
+
+    for file in $staticFileListTemp
+    do
+        file=${file#a\/} && saticFileList="$saticFileList $file"
+    done
+
 done
+
+srcFileList=$(_sortListUniq $srcFileList)
+testFileList=$(_sortListUniq $testFileList)
+toplevFileList=$(_sortListUniq $toplevFileList)
+staticFileList=$(_sortListUniq $staticFileList)
+
+echo
+echo INFO: srcFileList: $srcFileList
+echo
+
+echo
+echo INFO: testFileList: $testFileList
+echo
+
+echo
+echo INFO: toplevFileList: $toplevFileList
+echo
+
+echo
+echo INFO: staticFileList: $staticFileList
+echo
 
 
 $zeroCodeBase && {
@@ -242,8 +426,13 @@ $zeroCodeBase && {
     echo
 
     # First create destination for test files from currTag if missing
-    _createTestFilesDst $currTag $testFileList
+    _createFilesDst $currTag $testFileList
 
+    # Second create any needed toplevel destination from currTag if missing
+    _createFilesDst $currTag $toplevFileList
+
+    # Third create any needed static files destination from currTag if missing
+    _createFilesDst $currTag $staticFileList
 
     # Then zero code base for source files from currTag
     _zeroCodeBase $currTag $srcFileList
@@ -253,6 +442,7 @@ $zeroCodeBase && {
 $zeroOnly && {  _warnFilelist; exit ;}
 
 err=0
+failedPatchList=""
 echo
 echo
 echo --------------------------------------------------------
@@ -262,10 +452,11 @@ do
     echo
     echo
     echo --------------------------------------------------------
-    echo "INFO: ----------------- Currently applying patch: $patchNum -----------------"
-    echo "INFO: cat $patchFile | $patchCmd"
-    cat $patchFile | $patchCmd
-    let err+=$?
+    echo "INFO: ----------------- Currently applying patch: $patchFile -----------------"
+    _patchSingle $patchFile
+    currErr=$?
+    let err+=$currErr
+    [[ $currErr -eq 0 ]] || failedPatchList="$failedPatchList $patchFile"
 done
 
 echo
@@ -277,12 +468,14 @@ if [[ $err -eq 0 ]]; then
     echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     exit
 else
-    echo WARNING: First patch attempt exit status: $err
+    echo WARNING: First patch attempt number of Errors: $err
     echo
     echo
     echo WARNING: There were errors while patching from TAG: $currTag
     echo WARNING: Most probably some of the files from the current patch were having changes
     echo WARNING: between the current PR and the tag deployed at the host/container.
+    echo
+    echo WARNING: failedPatchList: $failedPatchList
     echo
     echo
 
@@ -295,12 +488,16 @@ else
         echo WARNING: Restoring all files to their original version at TAG: $currTag
         echo
         echo
-        _createTestFilesDst $currTag $testFileList
+        _createFilesDst $currTag $testFileList
+        _createFilesDst $curTag $toplevFileList
+        _createFilesDst $curTag $staticFileList
         _zeroCodeBase $currTag $srcFileList
         echo
         echo
         echo WARNING: All files have been rolled back to their original version at TAG: $currTag
         _warnFilelist
+        echo
+        echo WARNING: failedPatchList: $failedPatchList
         exit 1
     }
     echo WARNING: TRYING TO START FROM ORIGIN/MASTER BRANCH INSTEAD:
@@ -316,46 +513,55 @@ fi
 
 echo
 echo --------------------------------------------------------
-echo "WARNING: Refreshing all files which are to be patched from origin/master branch:"
+echo "INFO: Refreshing all files which are to be patched from origin/master branch:"
 echo
 
-# First create destination for test files from master if missing
-_createTestFilesDst "master" $testFileList
+# First create destination for test,static and toplevel files from master if missing
+_createFilesDst "master" $testFileList
+_createFilesDst "master" $toplevFileList
+_createFilesDst "master" $staticFileList
 
 # Then zero code base for source files from master
 _zeroCodeBase "master" $srcFileList
 
 err=0
+failedPatchList=""
 echo
 echo
 echo --------------------------------------------------------
-echo "WARNING: Patching all files starting from origin/master branch"
+echo "INFO: Patching all files starting from origin/master branch"
 for patchFile in $patchFileList
 do
     echo
     echo
-    echo "WARNING: --------------- Currently applying patch: $patchNum ---------------"
-    echo "WARNING: cat $patchFile | $patchCmd"
-    cat $patchFile | $patchCmd
-    let err+=$?
+    echo "INFO: --------------- Currently applying patch: $patchFile ---------------"
+    _patchSingle $patchFile
+    currErr=$?
+    let err+=$currErr
+    [[ $currErr -eq 0 ]] || failedPatchList="$failedPatchList $patchFile"
 done
 
 
 echo
 echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-echo WARNING: Second patch attempt exit status: $err
+echo INFO: Second patch attempt number of Errors: $err
 echo
 echo
 
 [[ $err -eq 0 ]] || {
 
-    _createTestFilesDst $currTag $testFileList
+    # Restore test, static, toplevel and source files to their original version
+    _createFilesDst $currTag $testFileList
+    _createFilesDst $currTag $toplevFileList
+    _createFilesDst $currTag $staticFileList
     _zeroCodeBase $currTag $srcFileList
 
     echo
     echo +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     echo WARNING: There were errors while patching from master branch as well
     echo WARNING: All files have been rolled back to their original version at TAG: $currTag
+    echo
+    echo WARNING: failedPatchList: $failedPatchList
     echo
     echo
 }


### PR DESCRIPTION
Fixes #12345 

#### Status
Ready

#### Description
With the current change all patch files provided to the script `patchComponent.sh`  either through `<PR number>` or `<patchFile at the command line>` or `<stdin>` are split in separate  `*.patch` files according to the source  file edited  in the original patch file and are applied separately, preserving the order they have been provided. This way depending on the source file we can properly determine all `patch` command parameters like `stripLevel` and `destination` so that we  can properly handle any file distributed with our packages not only those coming from `WMCore/src/python`

For this patch files splitting, the standard command `csplit` is used. It is distributed with the `coreutils` package, which is available at all our service  instances, so no new dependency is introduced with this PR

**Validation steps:**

here is how I was  testing this change while developing (I chose two related PRs both updating overlapping sets of source files including some toplevel source files as well) :

* WMAgent@docker:
```
(WMAgent-2.3.10rc17) [root@vocms0290:data]# ./patchComponent.sh 12302 12312 2>&1 |tee /tmp/12302.log
```
* WMAgent@Venv:

```
(WMAgent.venv3) [cmst1@vocms0290 WMCore]$ ./patchComponent.sh 12302 12312 2>&1 |tee /tmp/12302.log
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
