### PR TITLE
Further fixes to test workflow JSON templates

### DIFF
--- a/test/data/ReqMgr/inject-test-wfs.py
+++ b/test/data/ReqMgr/inject-test-wfs.py
@@ -39,6 +39,9 @@ def makeSiteWhitelist(jsonName, siteList):
     elif 'LHE' in jsonName or 'DQMHarvest' in jsonName:
         siteList = ["T2_CH_CERN"]
         print("Overwritting SiteWhitelist to: %s" % siteList)
+    elif 'ReReco_RunBlocklists_Parents' in jsonName or 'Parent_LumiMask' in jsonName:
+        siteList = ["T1_US_FNAL"]
+        print("Overwritting SiteWhitelist to: %s" % siteList)
     return siteList
 
 
@@ -204,9 +207,7 @@ def main():
         templates = os.listdir(wmcorePath)
 
     # Filter out templates not allowed to be injected
-    disallowedList = ['ReReco_badBlocks.json', 'TaskChain_InclParents.json',
-                      'StepChain_InclParents.json', 'SC_Straight.json',
-                      'StoreResults.json', 'Resub_MonteCarlo_eff.json', 'Resub_TaskChain_Multicore.json']
+    disallowedList = ['ReReco_badBlocks.json', 'StoreResults.json', 'Resub_TaskChain_Multicore.json']
     logger.info("Skipping injection for these templates: %s\n", disallowedList)
     templates = [item for item in templates if item not in disallowedList]
     if not templates:
@@ -228,7 +229,7 @@ def main():
         strComand = "%s %s -u %s -f %s -i " % (pythonCmd, reqMgrCommand, args.url, tmpFile)
 
         # read the original json template
-        with open(wmcorePath + fname) as fo:
+        with open(wmcorePath + fname, encoding='utf-8') as fo:
             jsonData = json.load(fo)
 
         # tweak the create dict
@@ -244,7 +245,7 @@ def main():
             handleAssignment(args, fname, jsonData)
 
         # Dump the modified json in a temp file and use just it
-        with open(tmpFile, "w") as outfile:
+        with open(tmpFile, "w", encoding='utf-8') as outfile:
             json.dump(jsonData, outfile)
 
         if args.dryRun:

--- a/test/data/ReqMgr/requests/DMWM/ReReco_RunBlocklists_Parents.json
+++ b/test/data/ReqMgr/requests/DMWM/ReReco_RunBlocklists_Parents.json
@@ -42,7 +42,7 @@
         "GlobalTag": "130X_dataRun3_Prompt_v4",
         "IncludeParents": true,
         "InputDataset": "/MinimumBias/Run2023C-22Sep2023_v4-v1/MINIAOD",
-        "Memory": 3000,
+        "Memory": 4000,
         "Multicore": 2,
         "PrepID": "TEST-ReReco-Run2023C-MinimumBias-JMENano12p5_v4-00001",
         "ProcessingString": "JMENano12p5_v4",

--- a/test/data/ReqMgr/requests/DMWM/SC_ProdPsi.json
+++ b/test/data/ReqMgr/requests/DMWM/SC_ProdPsi.json
@@ -41,8 +41,7 @@
                 "MC harvesting; Automatic EventBased and EventAwareLumiBased splitting; StepChain Disk and Tape rules "
             ],
             "WorkFlowDesc": [
-                "TC MC from scratch without PU; Step1 with 300EpJ instead of 261EpJ; Step2 with 480EpJ; Step3 with 480;",
-                "Step2/3 with EventAwareLumiBased; FirstEvent=10001, FirstLumi=101; Rucio container rule for Disk"
+                "SC MC from scratch; EventBased splitting with 700EpJ; FirstLumi=101; Rucio container rule for Disk"
             ]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
@@ -97,6 +96,7 @@
             "ConfigCacheID": "527f598f9168f0145d17417be583db58",
             "EventStreams": 2,
             "GlobalTag": "120X_mcRun3_2021_realistic_v4",
+            "KeepOutput": false,
             "InputFromOutputModule": "FEVTDEBUGoutput",
             "InputStep": "GenSimFull",
             "Multicore": 8,

--- a/test/data/ReqMgr/requests/DMWM/TC_ProdPsi.json
+++ b/test/data/ReqMgr/requests/DMWM/TC_ProdPsi.json
@@ -34,7 +34,7 @@
         "Comments": {
             "CheckList": ["TaskChain MC from scratch; TaskChain extension; TaskChain with transient Task2 GEN-SIM-DIGI-RAW output;  ",
                           "MC harvesting; Automatic EventBased and EventAwareLumiBased splitting; TaskChain Disk and Tape rules "],
-            "WorkFlowDesc": ["TC MC from scratch without PU; Task1 with 300EpJ instead of 261EpJ; Task2 with 480EpJ; Task3 with 480;",
+            "WorkFlowDesc": ["TC MC from scratch without PU; Task1 with 300EpJ instead of 261EpJ; Task2 with 320EpJ; Task3 with 480;",
                              "Task2/3 with EventAwareLumiBased; FirstEvent=10001, FirstLumi=101; Rucio container rule for Disk"]
         }, 
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 

--- a/test/data/ReqMgr/requests/Integration/SC_6Tasks_PU.json
+++ b/test/data/ReqMgr/requests/Integration/SC_6Tasks_PU.json
@@ -41,8 +41,8 @@
                 "StepChain multicore/eventStreams; StepChain with different CMSSW/ScramArch and PrepID"
             ],
             "WorkFlowDesc": [
-                "TC from scratch with PU at Step3; KeepOutput of Step5/6 only - AOD and MINI; Diff CMSSW/ScramArch and PrepID",
-                "2000EpJ and 4LpJ for Step1; Diff Multicore/Memory/EventStreams, T1: 2/1GB/2, T2: 4/2GB/0, T3: 4/4GB/0, T4: 2/4GB/2, T5:4/3GB/0, T6: 1/3GB/2"
+                "SC from scratch with PU at Step3; KeepOutput of Step5/6 only - AOD and MINI; Diff CMSSW/ScramArch and PrepID",
+                "2000EpJ and 4LpJ for Step1; 4GB of RAM for all steps and Cores/EventStream as: S1 2/2, S2 4/0, S3 4/0, S4 2/2, S5 4/0, S6 1/2"
             ]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",

--- a/test/data/ReqMgr/requests/Integration/SC_GPU.json
+++ b/test/data/ReqMgr/requests/Integration/SC_GPU.json
@@ -30,8 +30,8 @@
         "CMSSWVersion": "CMSSW_15_0_0_pre3",
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
-            "CheckList": "",
-            "WorkFlowDesc": ""
+            "CheckList": "SC with required GPU in all 3 steps; 2 cores top level, but steps asking for 8; 8GB RAM",
+            "WorkFlowDesc": "SC with required GPU; 8 cores and 8GB RAM per step"
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -44,8 +44,8 @@
         "GPUParams": "null",
         "GlobalTag": "142X_mcRun3_2025_realistic_v5",
         "IncludeParents": false,
-        "Memory": 3000,
-        "Multicore": 1,
+        "Memory": 8000,
+        "Multicore": 2,
         "PrepID": "TEST-CMSSW_15_0_0_pre3__Run3_AMD_GPUValidation_SpecialRV_CNAF-TTbar_14TeV-00001",
         "ProcessingString": "DEFAULT_ProcStr",
         "ProcessingVersion": 1,

--- a/test/data/ReqMgr/requests/Integration/SC_MCRecyc.json
+++ b/test/data/ReqMgr/requests/Integration/SC_MCRecyc.json
@@ -33,7 +33,7 @@
         "Comments": {
             "WorkFlowDesc": [
                 "StepChain MC recyling with 4CPU/8GB and 8CPU/8GB; with harvesting enabled; Different PrepID and CMSSW;",
-                "Different AcqEra/ProcStr/ProcVer; 5L for Step1 and 10L for Step2"
+                "Different AcqEra/ProcStr/ProcVer; Diff CMSSW versions, with 15_0_1 for Step2; 5LpJ"
             ],
             "CheckList": [
                 "StepChain: MC recycling; StepChain MC harvesting; StepChain PrimaryDataset override",
@@ -86,8 +86,8 @@
             "StepName": "DIGIHI2024"
         },
         "Step2": {
-            "AcquisitionEra": "CMSSW_15_0_0_pre3",
-            "CMSSWVersion": "CMSSW_15_0_0_pre3",
+            "AcquisitionEra": "CMSSW_15_0_1",
+            "CMSSWVersion": "CMSSW_15_0_1",
             "Campaign": "CMSSW_15_0_0_pre3__Run3_2024HIN_noPU_Reference-1739207270",
             "ConfigCacheID": "574bef09fdd0275b3eae2ca9e87ca048",
             "EventStreams": 2,

--- a/test/data/ReqMgr/requests/Integration/SC_MCRecyc_PU.json
+++ b/test/data/ReqMgr/requests/Integration/SC_MCRecyc_PU.json
@@ -33,7 +33,7 @@
         "Comments": {
             "WorkFlowDesc": [
                 "StepChain MC recycling with PU; Very similar to TC_MCRecyc.json but with PU that is not used in cmsDriver;",
-                "Also, same CMSSW version in both tasks; KeepOutput false for Step1 (GEN-SIM-*)"
+                "Diff CMSSW versions, 15_0_0_pre3 for Step1, 15_0_1 for Step2; KeepOutput false for Step1 (GEN-SIM-*)"
             ],
             "CheckList": "StepChain: MC recycling with PU; StepChain with KeepOutput false; StepChain MC harvesting"
         },
@@ -82,8 +82,8 @@
             "StepName": "DIGIHI2024"
         },
         "Step2": {
-            "AcquisitionEra": "CMSSW_15_0_0_pre3",
-            "CMSSWVersion": "CMSSW_15_0_0_pre3",
+            "AcquisitionEra": "CMSSW_15_0_1",
+            "CMSSWVersion": "CMSSW_15_0_1",
             "Campaign": "CMSSW_15_0_0_pre3__Run3_2024HIN_noPU-1739709162",
             "ConfigCacheID": "574bef09fdd0275b3eae2ca9e87ca048",
             "EventStreams": 2,

--- a/test/data/ReqMgr/requests/Integration/SC_Nano.json
+++ b/test/data/ReqMgr/requests/Integration/SC_Nano.json
@@ -26,10 +26,10 @@
         "CMSSWVersion": "CMSSW_10_6_26",
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
-            "CheckList": "StepChain with Dataset start policy",
+            "CheckList": "StepChain with Dataset start policy; EventAwareLumiBased splitting hardcoded to 10k EpJ (10 lumis)",
             "WorkFlowDesc": [
-                "TC processing a MINIAODSIM, thus locking all of the input blocks at the same location (with copies=2);",
-                "Request 4GB and 2 cores; Job splitting hardcoded to 40k EpJ and 40k EpL"
+                "SC processing a MINIAODSIM, thus locking all of the input blocks at the same location (with copies=2);",
+                "Request 4GB and 2 cores; Job splitting hardcoded to 10k EpJ (input data with 1k EpL"
             ]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
@@ -41,7 +41,7 @@
         "GPUParams": "null",
         "GlobalTag": "106X_mc2017_realistic_v9",
         "IncludeParents": false,
-        "Memory": 3000,
+        "Memory": 4000,
         "Multicore": 1,
         "PrepID": "TEST-task_SMP-RunIISummer20UL17NanoAODv9-00184",
         "ProcessingString": "DEFAULT_ProcStr",
@@ -59,8 +59,7 @@
             "CMSSWVersion": "CMSSW_10_6_26",
             "Campaign": "RunIIAutumn18NanoAODv5",
             "ConfigCacheID": "0fd238f99b39e8fef9f658d1dd1d6f61",
-            "EventsPerJob": 40000,
-            "EventsPerLumi": 40000,
+            "EventsPerJob": 10000,
             "FilterEfficiency": 1,
             "GlobalTag": "106X_mc2017_realistic_v9",
             "InputDataset": "/WplusToJJZToLNuJJ_mjj100_pTj10_QCD_LO_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM",
@@ -76,6 +75,6 @@
             "StepName": "Step1_NanoAODv9"
         },
         "StepChain": 1,
-        "TimePerEvent": 0.3796
+        "TimePerEvent": 2.4
     }
 }

--- a/test/data/ReqMgr/requests/Integration/SC_Parent_LumiMask.json
+++ b/test/data/ReqMgr/requests/Integration/SC_Parent_LumiMask.json
@@ -38,6 +38,7 @@
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "DbsUrl": "https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader",
         "GlobalTag": "130X_dataRun3_Prompt_v4",
+        "Memory": 4000,
         "PrepID": "TEST-CMSSW_7_3_2__test2inwf-1510737328-RunHLTPhy2017B_RAWAOD",
         "ProcessingString": "DMWM_ProcStr_TEST",
         "ProcessingVersion": 18,
@@ -101,6 +102,6 @@
             "StepName": "DQMHLTonRAWAOD_2017"
         },
         "StepChain": 1,
-        "TimePerEvent": 110.5
+        "TimePerEvent": 55.5
     }
 }

--- a/test/data/ReqMgr/requests/Integration/SC_ProdPsi_Nvidia.json
+++ b/test/data/ReqMgr/requests/Integration/SC_ProdPsi_Nvidia.json
@@ -30,8 +30,8 @@
         "CMSSWVersion": "CMSSW_12_0_0",
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
-            "CheckList": "StepChain MC from scratch; StepChain requiring GPU; KeepOutput false for Step1/Step2",
-            "WorkFlowDesc": "TC MC from scratch without PU; StepChain requiring some made-up GPU for Step1 and Step3;"
+            "CheckList": "StepChain MC from scratch; StepChain requiring GPU on Step1, optional on Step3; KeepOutput false for Step1/Step2",
+            "WorkFlowDesc": "SC MC from scratch without PU; StepChain requiring some made-up GPU for Step1 and Step3; 8 cores and 8GB RAM per step"
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -41,8 +41,8 @@
         "GPUParams": "null",
         "GlobalTag": "120X_mcRun3_2021_realistic_v4",
         "IncludeParents": false,
-        "Memory": 3000,
-        "Multicore": 1,
+        "Memory": 8000,
+        "Multicore": 2,
         "PrepID": "TEST-CMSSW_12_0_0__PDMVRELVALS-128_2021noPU-Psi2SToJPsiPiPi-00001",
         "ProcessingString": "DEFAULT_ProcStr",
         "ProcessingVersion": 1,

--- a/test/data/ReqMgr/requests/Integration/TC_MCRecyc.json
+++ b/test/data/ReqMgr/requests/Integration/TC_MCRecyc.json
@@ -32,7 +32,7 @@
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
             "WorkFlowDesc": ["TaskChain MC recyling with 4CPU/6GB and 8CPU/8GB; with harvesting enabled; Different PrepID and CMSSW;",
-                             "Different AcqEra/ProcStr/ProcVer; 5L for Task1 and 10L for Task2"],
+                             "Different AcqEra/ProcStr/ProcVer; 5L for Task1 and 10L for Task2; 15_0_0_pre3 for Task1, 15_0_1 for Task2"],
 	        "CheckList": ["TaskChain: MC recycling; TaskChain MC harvesting; TaskChain PrimaryDataset override",
                           "TaskChain with different AcqEra/ProcStr/ProcVer and PrepID/CMSSW; LumiBased splitting"]
         },
@@ -82,8 +82,8 @@
             "TaskName": "DIGIHI2024"
         },
         "Task2": {
-            "AcquisitionEra": "CMSSW_15_0_0_pre3",
-            "CMSSWVersion": "CMSSW_15_0_0_pre3",
+            "AcquisitionEra": "CMSSW_15_0_1",
+            "CMSSWVersion": "CMSSW_15_0_1",
             "Campaign": "CMSSW_15_0_0_pre3__Run3_2024HIN_noPU_Reference-1739207270",
             "ConfigCacheID": "574bef09fdd0275b3eae2ca9e87ca048",
             "EventStreams": 2,

--- a/test/data/ReqMgr/requests/Integration/TC_MCRecyc_PU.json
+++ b/test/data/ReqMgr/requests/Integration/TC_MCRecyc_PU.json
@@ -32,8 +32,8 @@
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
             "WorkFlowDesc": ["TaskChain MC recycling with PU; Very similar to TC_MCRecyc.json but with PU that is not used in cmsDriver;",
-                             "Also, same CMSSW version in both tasks; KeepOutput false for Task1 (GEN-SIM-*)"],
-	        "CheckList": "TaskChain: MC recycling with PU; TaskChain with KeepOutput false; TaskChain MC harvesting"
+                             "Also, same CMSSW version in both tasks; KeepOutput false for Task1 (GEN-SIM-*); 15_0_0_pre3 for Task1, 15_0_1 for Task2"],
+	        "CheckList": "TaskChain: MC recycling with PU; TaskChain with KeepOutput false; TaskChain MC harvesting; TC with diff CMSSW versions"
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -81,8 +81,8 @@
             "TaskName": "DIGIHI2024"
         },
         "Task2": {
-            "AcquisitionEra": "CMSSW_15_0_0_pre3",
-            "CMSSWVersion": "CMSSW_15_0_0_pre3",
+            "AcquisitionEra": "CMSSW_15_0_1",
+            "CMSSWVersion": "CMSSW_15_0_1",
             "Campaign": "CMSSW_15_0_0_pre3__Run3_2024HIN_noPU-1739709162",
             "ConfigCacheID": "574bef09fdd0275b3eae2ca9e87ca048",
             "EventStreams": 2,

--- a/test/data/ReqMgr/requests/Integration/TC_Nano.json
+++ b/test/data/ReqMgr/requests/Integration/TC_Nano.json
@@ -28,7 +28,7 @@
         "Comments": {
             "CheckList": "TaskChain with Dataset start policy",
             "WorkFlowDesc": ["TC processing a MINIAODSIM, thus locking all of the input blocks at the same location (with copies=2);",
-                             "Request 4GB and 2 cores; Job splitting hardcoded to 40k EpJ and 40k EpL"]
+                             "Request 4GB and 2 cores; Job splitting hardcoded to 12k EpJ and 12k EpL"]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -57,8 +57,8 @@
             "CMSSWVersion": "CMSSW_10_6_26",
             "Campaign": "RunIIAutumn18NanoAODv5",
             "ConfigCacheID": "0fd238f99b39e8fef9f658d1dd1d6f61",
-            "EventsPerJob": 40000,
-            "EventsPerLumi": 40000,
+            "EventsPerJob": 12000,
+            "EventsPerLumi": 12000,
             "FilterEfficiency": 1,
             "GlobalTag": "106X_mc2017_realistic_v9",
             "InputDataset": "/WplusToJJZToLNuJJ_mjj100_pTj10_QCD_LO_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM",


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11860
Complement to https://github.com/dmwm/WMCore/pull/11949

#### Status
ready

#### Description
This PR brings in 3 relevant changes:
1) update inject-test-wfs script to assign workflows with Parents to FNAL only; in addition, remove some disallowed templates that no longer exist;
2) update resources for a Parents DMWM template
3) update resources, job splitting and comments for Integration templates

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Correcting a few issues that slipped through with https://github.com/dmwm/WMCore/pull/11949

#### External dependencies / deployment changes
None