### PR TITLE
default stageout commands for protocols

### DIFF
--- a/src/python/WMCore/Storage/RucioFileCatalog.py
+++ b/src/python/WMCore/Storage/RucioFileCatalog.py
@@ -293,7 +293,7 @@ def get_default_cmd(currentSite, currentSubsite, storageSite, volume, protocolNa
             # Map scheme to command
             return {
                 'root': 'xrdcp',
-                'davs': 'gfla2',
+                'davs': 'gfal2',
                 'file': 'cp'
             }.get(url_scheme, 'gfal2')
 

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -13,7 +13,7 @@ import os
 from builtins import next, str, object
 
 from WMCore.Algorithms.ParseXMLFile import xmlFileToNode
-from WMCore.Storage.RucioFileCatalog import rseName
+from WMCore.Storage.RucioFileCatalog import rseName,get_default_cmd
 
 
 def loadSiteLocalConfig():
@@ -300,14 +300,15 @@ def processStageOut():
 
             localReport = {}
             localReport['storageSite'] = aStorageSite
-            localReport['command'] = subnode.attrs.get('command', None)
-            # use default command='gfal2' when 'command' is not specified
-            if localReport['command'] is None:
-                localReport['command'] = 'gfal2'
+            #Do not support 'command' from site-local-config.xml anymore
+            #get command based on rule PFN or prefix of the protocol for example root://, davs:// file://
+            if aProtocol is None: localReport['command'] = None
+            else: localReport['command'] = get_default_cmd(report["siteName"], subSiteName, aStorageSite, aVolume, aProtocol)
             localReport['option'] = subnode.attrs.get('option', None)
             localReport['volume'] = aVolume
             localReport['protocol'] = aProtocol
             localReport['phedex-node'] = rseName(report["siteName"], subSiteName, aStorageSite, aVolume)
+            
             report['stageOuts'].append(localReport)
 
 

--- a/src/python/WMCore/Storage/SiteLocalConfig.py
+++ b/src/python/WMCore/Storage/SiteLocalConfig.py
@@ -13,7 +13,7 @@ import os
 from builtins import next, str, object
 
 from WMCore.Algorithms.ParseXMLFile import xmlFileToNode
-from WMCore.Storage.RucioFileCatalog import rseName,get_default_cmd
+from WMCore.Storage.RucioFileCatalog import rseName, get_default_cmd
 
 
 def loadSiteLocalConfig():
@@ -73,7 +73,6 @@ class SiteConfigError(Exception):
     Exception class placeholder
 
     """
-    pass
 
 
 class SiteLocalConfig(object):
@@ -138,7 +137,7 @@ class SiteLocalConfig(object):
         except Exception as ex:
             msg = "Unable to read SiteConfigFile: %s\n" % self.siteConfigFile
             msg += str(ex)
-            raise SiteConfigError(msg)
+            raise SiteConfigError(msg) from ex
 
         nodeResult = nodeReader(node)
 
@@ -308,7 +307,7 @@ def processStageOut():
             localReport['volume'] = aVolume
             localReport['protocol'] = aProtocol
             localReport['phedex-node'] = rseName(report["siteName"], subSiteName, aStorageSite, aVolume)
-            
+
             report['stageOuts'].append(localReport)
 
 

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -73,7 +73,7 @@ class SiteLocalConfigTest(unittest.TestCase):
             "Error: Protocol is not correct."
         assert mySiteConfig.stageOuts[0]["option"] == "-p", \
             "Error: option is not correct."
-        # assert False
+        #assert False
         return
 
     def testLoadingConfigFromOverridenEnvVarriable(self):

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -33,6 +33,7 @@ class SiteLocalConfigTest(unittest.TestCase):
         fnalConfigFileName = os.path.join(getTestBase(),
                                           "WMCore_t/Storage_t",
                                           "T1_US_FNAL_SiteLocalConfig.xml")
+        
         mySiteConfig = SiteLocalConfig(fnalConfigFileName)
 
         assert mySiteConfig.siteName == "T1_US_FNAL", "Error: Wrong site name."
@@ -66,13 +67,65 @@ class SiteLocalConfigTest(unittest.TestCase):
 
         assert len(goldenProxies) == 0, \
             "Error: Missing proxy servers."
-
+        
+        #test second stage out method with command extraction from rules
         assert mySiteConfig.stageOuts[0]["command"] == "xrdcp", \
             "Error: Wrong stage out command."
         assert mySiteConfig.stageOuts[0]["protocol"] == "XRootD", \
             "Error: Protocol is not correct."
         assert mySiteConfig.stageOuts[0]["option"] == "-p", \
             "Error: option is not correct."
+        
+        #assert False
+        return
+    
+    def testGetDefaultStageOutCmd(self):
+        """
+        _testGetDefaultStageOutCmd_
+
+        Verify that the default stage out command is returned correctly for given protocol.
+        """
+        os.environ['SITECONFIG_PATH'] = os.path.join(getTestBase(),
+                                                    'WMCore_t/Storage_t',
+                                                    'T1_DE_KIT')
+        configFileName = os.path.join(getTestBase(),
+                                          "WMCore_t/Storage_t",
+                                          "T1_DE_KIT/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml")
+       
+        mySiteConfig = SiteLocalConfig(configFileName)
+        #test the first stage out method with command extraction from prefix
+        assert mySiteConfig.stageOuts[0]["command"] == "gfal2", \
+            "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[0]["protocol"] == "WebDAV", \
+            "Error: Protocol is not correct."
+        #test the second stage out method with command extraction from rules
+        assert mySiteConfig.stageOuts[1]["command"] == "gfal2", \
+            "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[1]["protocol"] == "WebDAV", \
+            "Error: Protocol is not correct."
+        #test the third stage out method with no command found, fall to default gfal2
+        assert mySiteConfig.stageOuts[2]["command"] == "gfal2", \
+            "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[2]["protocol"] == "xrootd-module", \
+            "Error: Protocol is not correct."
+        #test the fourth stage out method with "prefix": "root://172.26.19.197:1094//root://cmsxrootd-test.gridka.de:1094/"
+        assert mySiteConfig.stageOuts[3]["command"] == "xrdcp", \
+            "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[3]["protocol"] == "XRootDHoreKaGridKa", \
+            "Error: Protocol is not correct."
+        
+        os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_IT_CNAF'
+        configFileName = os.path.join(getTestBase(),
+                                          "WMCore_t/Storage_t",
+                                          "T1_IT_CNAF_SiteLocalConfig.xml")
+       
+        mySiteConfig = SiteLocalConfig(configFileName)
+        #test the first stage out method for command 'cp' with protocol 'file'
+        assert mySiteConfig.stageOuts[0]["command"] == "cp", \
+            "Error: Wrong stage out command."
+        assert mySiteConfig.stageOuts[0]["protocol"] == "file", \
+            "Error: Protocol is not correct."
+
         #assert False
         return
 

--- a/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
+++ b/test/python/WMCore_t/Storage_t/T1_DE_KIT/JobConfig/site-local-config-testStageOut-T1_DE_KIT.xml
@@ -33,7 +33,11 @@
 		</fallback-stage-out>
 
 		<stage-out>
-        <method volume="KIT_dCache" protocol="WebDAV"/>
+		    <method volume="KIT_dCache" protocol="WebDAV"/>
+		    <method volume="KIT_MSS" protocol="WebDAV"/>
+			<method volume="KIT_dCache" protocol="xrootd-module"/>
+			<method volume="KIT_dCache" protocol="XRootDHoreKaGridKa"/>
+            <method site="T2_DE_DESY" volume="DESY_dCache" protocol="WebDAV"/>
 		</stage-out>
 
 		<calib-data>

--- a/test/python/WMCore_t/Storage_t/T1_IT_CNAF_SiteLocalConfig.xml
+++ b/test/python/WMCore_t/Storage_t/T1_IT_CNAF_SiteLocalConfig.xml
@@ -1,0 +1,50 @@
+<site-local-config>
+<site name="T1_IT_CNAF">
+   <event-data>
+     <catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=file"/>
+     <catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=xrootd"/>
+   </event-data>
+    <data-access>
+        <catalog volume="CNAF_GPFS" protocol="file"/>
+        <catalog volume="Eurasian_Federation" protocol="XRootD"/>
+    </data-access>
+   <source-config>
+     <statistics-destination name="cms-udpmon-collector.cern.ch:9331" />
+   </source-config>
+   <local-stage-out>
+     <catalog url="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=davs"/>
+     <se-name value="storm-fe-cms.cr.cnaf.infn.it"/>
+     <phedex-node value="T1_IT_CNAF_Disk"/>
+     <command value="gfal2"/>
+     <option value="-v "/>
+   </local-stage-out>
+    <fallback-stage-out>
+     <se-name value="t2-srm-02.lnl.infn.it"/>
+     <phedex-node value="T2_IT_Legnaro"/>
+     <lfn-prefix value="davs://t2-xrdcms.lnl.infn.it:2880/pnfs/lnl.infn.it/data/cms"/>
+     <command value="gfal2"/>
+   </fallback-stage-out>
+    <stage-out>
+    <method volume="CNAF_GPFS" protocol="file"/>
+    <method volume="CNAF_GPFS" protocol="WebDAV" option="-v"/>
+		<method site="T2_IT_Legnaro" volume="Legnaro_dCache" protocol="WebDAV"/>
+	</stage-out>
+    <calib-data>
+      <frontier-connect>
+       <load balance="proxies"/>
+        <proxy url="http://squid-lhc-01.cr.cnaf.infn.it:3128"/>
+        <proxy url="http://squid-lhc-02.cr.cnaf.infn.it:3128"/>
+        <proxy url="http://squid-lhc-03.cr.cnaf.infn.it:3128"/>
+        <proxy url="http://squid-lhc-04.cr.cnaf.infn.it:3128"/>
+        <proxy url="http://squid-lhc-05.cr.cnaf.infn.it:3128"/>
+        <proxy url="http://squid-lhc-06.cr.cnaf.infn.it:3128"/>
+        <backupproxy url="http://cmsbpfrontier.cern.ch:3128"/>
+        <backupproxy url="http://cmsbproxy.fnal.gov:3128"/>
+        <server url="http://cmsfrontier.cern.ch:8000/FrontierInt"/>
+        <server url="http://cmsfrontier1.cern.ch:8000/FrontierInt"/>
+        <server url="http://cmsfrontier2.cern.ch:8000/FrontierInt"/>
+        <server url="http://cmsfrontier3.cern.ch:8000/FrontierInt"/>
+      </frontier-connect>
+    </calib-data>
+</site>
+</site-local-config>

--- a/test/python/WMCore_t/Storage_t/T1_US_FNAL_SiteLocalConfig.xml
+++ b/test/python/WMCore_t/Storage_t/T1_US_FNAL_SiteLocalConfig.xml
@@ -14,7 +14,8 @@
     <phedex-node value="T1_US_FNAL_Disk"/>
   </local-stage-out>
   <stage-out>
-    <method volume="FNAL_dCache_EOS" protocol="XRootD" command="xrdcp" option="-p"/>
+    <method volume="FNAL_dCache_EOS" protocol="XRootD" option="-p"/>
+    <method volume="FNAL_dCache_EOS" protocol="xrootd"/>
     <method volume="FNAL_dCache_EOS" protocol="SRMv2"/>
     <method volume="FNAL_dCache_EOS" protocol="WebDAV"/>
   </stage-out>


### PR DESCRIPTION
Fixes #12314

#### Status
Ready

#### Description
Add a function, get_default_cmd, in RucioFileCatalog.py to identify the default command from the stageout command

#### Is it backward compatible (if not, which system it affects?)
NO. The "command" definition in stageout methods will be ineffective
