### PR TITLE
Change look-up states for process status

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -308,7 +308,9 @@ class WMAgentDBData(object):
                 # check if all component process' threads are alive, otherwise set down flag
                 for proc in compProcessStatus:
                     # the alive process should be either in sleeping or running states
-                    if proc['status'] not in ["S (sleeping)", "R (running)"]:
+                    # 'S (sleeping) and 'R (running)' are states used by proc FS
+                    # 'sleeping' and 'running' are states used by psutils
+                    if proc['status'] not in ["S (sleeping)", "R (running)", 'sleeping', 'running']:
                         downFlag = True
                         downProcessThreads.append(proc)
             if downFlag and component not in agentInfo['down_components']:

--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -41,7 +41,7 @@ def threadsDetails(component, pid, downProcessThreads):
             "last_updated": int(time.time()),
             "update_threshold": None,
             "poll_interval": None,
-            "cycle_time": None,
+            "cycle_time": 0.0,
             "outcome": None,
             "last_error": None,
             "error_message": f"Lost threads: {downProcessThreads}"


### PR DESCRIPTION
Fixes #12145 

#### Status
ready

The change is tested directly on the agent by re-using `DataCollectAPI.py` codebase to identify process status. Here is code used for testing and its results:
```
# store this on ~/daemon_status.py
import os
import json
from WMCore.Agent.Daemon.Details import Details

def testComponent(daemonXml, compDir):
    daemon = Details(daemonXml)
    downFlag = False
    if not daemon.isAlive():
        downFlag = True
    # add individual component thread status
    compName = compDir.split('/')[-1]
    compProcessStatus = daemon.processStatus()
    cpath = os.path.join(compDir, "threads.json")
    downProcessThreads = []
    if os.path.exists(cpath):
        origThreads = []
        with open(cpath, 'r', encoding='utf-8') as istream:
            origThreads = json.load(istream)
        if len(origThreads) != len(compProcessStatus):
            downFlag = True
            for proc in origThreads:
                if proc not in compProcessStatus:
                    downProcessThreads.append(proc)
    # check if all component process' threads are alive, otherwise set down flag
    for proc in compProcessStatus:
        # the alive process should be either in sleeping or running states
        print("### proc", proc)
        if proc['status'] not in ["S (sleeping)", "R (running)"]:
            downFlag = True
            downProcessThreads.append(proc)


if __name__ == "__main__":
    daemonXml = '/data/srv/wmagent/current/install/DBS3Upload/Daemon.xml'
    compDir = '/data/srv/wmagent/current/install/DBS3Upload/'
    testComponent(daemonXml, compDir)
```
and, I run it on vocms0192 as following:
```
python  ~/daemon_status.py
### proc {'process': 'python', 'pid': '1105', 'status': 'sleeping', 'type': 'process'}
### proc {'process': 'python-thread', 'pid': '1106', 'status': 'running', 'type': 'thread'}
### proc {'process': 'python-thread', 'pid': '1114', 'status': 'running', 'type': 'thread'}
```
Based on output of status values provided via `psutil` (instead of originally implemented `procfs` this PR accordingly provided the necessary changes.

#### Description
Adjust values to check for running/sleeping process status values based on `psutils` vs `procfs` look-up of the state, see above test.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
- https://github.com/dmwm/WMCore/pull/12302
- https://github.com/dmwm/WMCore/pull/12362

#### External dependencies / deployment changes
