### PR TITLE
Avoid token-based file deletion in GFAL2, unless environ is defined

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -5,7 +5,7 @@ Implementation of StageOutImpl interface for gfal-copy
 """
 import argparse
 import os
-
+import logging
 from WMCore.Storage.Registry import registerStageOutImpl
 from WMCore.Storage.StageOutImpl import StageOutImpl
 
@@ -84,10 +84,16 @@ class GFAL2Impl(StageOutImpl):
         :forceMethod: bool to isolate and force a given authentication method
         :dryRun: bool, dry run mode (to enable debug mode)
         """
-        if authMethod is None:
-            set_auth = self.setAuthToken + " " + self.setAuthX509
-            unset_auth = ""
-        elif authMethod == 'X509':
+        if authMethod == 'TOKEN':
+            if not self.isBearerTokenFileSet():
+                msg = "File removal requested with tokens, but environment variable is not defined."
+                msg += " Forcing it to use X509 authentication method instead."
+                logging.info(msg)
+                authMethod = 'X509'
+        else:
+            authMethod = 'X509'
+
+        if authMethod == 'X509':
             set_auth = self.setAuthX509
             unset_auth = self.unsetToken if forceMethod else ""
         elif authMethod == 'TOKEN':

--- a/src/python/WMCore/Storage/DeleteMgr.py
+++ b/src/python/WMCore/Storage/DeleteMgr.py
@@ -10,8 +10,6 @@ Based on StageOutMgr class
 import logging
 
 from builtins import object
-from future.utils import viewitems
-
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Storage.RucioFileCatalog import storageJsonPath, readRFC
 from WMCore.Storage.SiteLocalConfig import stageOutStr, loadSiteLocalConfig
@@ -149,7 +147,7 @@ class DeleteMgr(object):
         self.overrideConf = overrideConf
 
         msg = "=======Delete Override Initialised:================\n"
-        for key, val in viewitems(overrideConf):
+        for key, val in overrideConf.items():
             msg += " %s : %s\n" % (key, val)
         msg += "=====================================================\n"
         self.logger.info(msg)
@@ -250,6 +248,6 @@ class DeleteMgr(object):
             impl.removeFile(pfn)
         except Exception as ex:
             self.logger.exception("Failed to delete file: %s", pfn)
-            raise ex
+            raise ex from None
 
         return pfn

--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -71,6 +71,17 @@ class StageOutImpl:
         echo
         """
 
+    def isBearerTokenFileSet(self):
+        """
+        Method to check if the BEARER_TOKEN_FILE environment variable is
+        set and not empty. If so, whether the file exists.
+        :return: True if BEARER_TOKEN_FILE envir var is set and exists, False otherwise.
+        """
+        if os.getenv("BEARER_TOKEN_FILE"):
+            if os.path.exists(os.getenv("BEARER_TOKEN_FILE")):
+                return True
+        return False
+
     @staticmethod
     def splitPFN(pfn):
         """

--- a/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
@@ -1,7 +1,8 @@
 from __future__ import (print_function, division)
 
 import unittest
-
+import os
+import tempfile
 from mock import mock, call
 
 from WMCore.Storage.StageOutError import StageOutError
@@ -165,3 +166,16 @@ class StageOutImplTest(unittest.TestCase):
         mock_createOutputDirectory.assert_called_with("targetPFN")
         calls = [call(600), call(600)]
         mock_time.sleep.assert_has_calls(calls)
+
+    def testIsBearerTokenFileSet(self):
+        self.assertFalse(self.StageOutImpl.isBearerTokenFileSet())
+        os.environ["BEARER_TOKEN_FILE"] = ""
+        self.assertFalse(self.StageOutImpl.isBearerTokenFileSet())
+        os.environ["BEARER_TOKEN_FILE"] = "/test/token"
+        self.assertFalse(self.StageOutImpl.isBearerTokenFileSet())
+
+        with tempfile.NamedTemporaryFile(delete=True) as temp_file:
+            temp_file_path = temp_file.name
+            os.environ["BEARER_TOKEN_FILE"] = temp_file_path
+            self.assertTrue(self.StageOutImpl.isBearerTokenFileSet())
+        del os.environ["BEARER_TOKEN_FILE"]


### PR DESCRIPTION
Fixes #12376 
Complement to https://github.com/dmwm/WMCore/pull/12218

#### Status
ready

#### Description
Before setting TOKEN-based file deletion with GFAL2, verify if the required environment variable is actually defined (`BEARER_TOKEN_FILE`). If it is not, use X509 authentication regardless of which authentication mechanism has been requested within the storage interaction activity.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
