### PR TITLE
Add Oracle DatabaseError DPI-1080 as a soft error

### DIFF
--- a/src/python/WMCore/Database/DBExceptionHandler.py
+++ b/src/python/WMCore/Database/DBExceptionHandler.py
@@ -15,10 +15,12 @@ import threading
 # (cx_Oracle.InterfaceError) not connected  # same as ORA-03114, in the new SQLAlchemy
 # (cx_Oracle.DatabaseError) ORA-25408: can not safely replay call
 # (cx_Oracle.DatabaseError) ORA-25401: can not continue fetches
+# (cx_Oracle.DatabaseError) DPI-1080: connection was closed by ORA-3113
 # and those two MySQL exceptions
 DB_CONNECTION_ERROR_STR = ["ORA-03113", "ORA-03114", "ORA-03135", "ORA-12545", "ORA-00060", "ORA-01033",
                            "MySQL server has gone away", "Lock wait timeout exceeded",
-                           "(cx_Oracle.InterfaceError) not connected", "ORA-25408", "ORA-25401"]
+                           "(cx_Oracle.InterfaceError) not connected", "ORA-25408", "ORA-25401",
+                           "DPI-1080: connection was closed by ORA"]
 
 
 def db_exception_handler(f):


### PR DESCRIPTION
Fixes #12378 

#### Status
not-tested

#### Description
Add an Oracle error: `DPI-1080: connection was closed by ORA` to the list of soft database errors, hence ensuring that the component does not crash upon such failures.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
