### PR TITLE
Default first stage out to X509 in case bearer token is not set

### DIFF
--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -24,7 +24,8 @@ class GFAL2Impl(StageOutImpl):
         # GFAL2 is not build under COMP environment and it had failures with mixed environment.
 
         self.setAuthX509 = "X509_USER_PROXY=$X509_USER_PROXY"
-        self.setAuthToken = "BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE)"
+        # if BEARER_TOKEN_FILE is not set, use /dev/null as a fallback to suppress the error
+        self.setAuthToken = "BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat ${BEARER_TOKEN_FILE:-/dev/null})"
         self.unsetX509 = "unset X509_USER_PROXY;"
         self.unsetToken = "unset BEARER_TOKEN;"
 

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -84,7 +84,7 @@ class GFAL2Impl(StageOutImpl):
         :forceMethod: bool to isolate and force a given authentication method
         :dryRun: bool, dry run mode (to enable debug mode)
         """
-        if authMethod == 'TOKEN':
+        if authMethod and authMethod.upper() == 'TOKEN':
             if not self.isBearerTokenFileSet():
                 msg = "File removal requested with tokens, but environment variable is not defined."
                 msg += " Forcing it to use X509 authentication method instead."
@@ -145,10 +145,16 @@ class GFAL2Impl(StageOutImpl):
         copyCommandDict['source'] = self.createFinalPFN(sourcePFN)
         copyCommandDict['destination'] = self.createFinalPFN(targetPFN)
 
-        if authMethod is None:
-            copyCommandDict['set_auth'] = ""
-            copyCommandDict['unset_auth'] = ""
-        elif authMethod.upper() == 'X509':
+        if authMethod and authMethod.upper() == 'TOKEN':
+            if not self.isBearerTokenFileSet():
+                msg = "Stage out requested with tokens, but environment variable is not defined."
+                msg += " Forcing it to use X509 authentication method instead."
+                logging.info(msg)
+                authMethod = 'X509'
+        else:
+            authMethod = 'X509'
+
+        if authMethod.upper() == 'X509':
             copyCommandDict['set_auth'] = self.setAuthX509
             copyCommandDict['unset_auth'] = self.unsetToken if forceMethod else ""
         elif authMethod.upper() == 'TOKEN':

--- a/src/python/WMCore/Storage/Backends/GFAL2Impl.py
+++ b/src/python/WMCore/Storage/Backends/GFAL2Impl.py
@@ -145,7 +145,7 @@ class GFAL2Impl(StageOutImpl):
         copyCommandDict['source'] = self.createFinalPFN(sourcePFN)
         copyCommandDict['destination'] = self.createFinalPFN(targetPFN)
 
-        if authMethod and authMethod.upper() == 'TOKEN':
+        if authMethod and authMethod.upper() == 'TOKEN' and forceMethod is False:
             if not self.isBearerTokenFileSet():
                 msg = "Stage out requested with tokens, but environment variable is not defined."
                 msg += " Forcing it to use X509 authentication method instead."

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -111,14 +111,21 @@ class XRDCPImpl(StageOutImpl):
         authEnv = ""
         if authMethod is None:
             return authEnv
+
+        if authMethod.upper() == 'TOKEN':
+            if not self.isBearerTokenFileSet():
+                msg = "Stage out requested with tokens, but environment variable is not defined."
+                msg += " Forcing it to use X509 authentication method instead."
+                logging.info(msg)
+                authMethod = 'X509'
+        if authMethod.upper() == 'TOKEN':
+            authEnv = self.setAuthToken
+            if forceMethod:
+                authEnv += self.unsetX509
         elif authMethod.upper() == 'X509':
             authEnv = self.setAuthX509
             if forceMethod:
                 authEnv += self.unsetToken
-        elif authMethod.upper() == 'TOKEN':
-            authEnv = self.setAuthToken
-            if forceMethod:
-                authEnv += self.unsetX509
         else:
             logging.warning("Warning! Running without either a X509 certificate or a token specified!")
 

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -112,7 +112,7 @@ class XRDCPImpl(StageOutImpl):
         if authMethod is None:
             return authEnv
 
-        if authMethod.upper() == 'TOKEN':
+        if authMethod.upper() == 'TOKEN' and forceMethod is False:
             if not self.isBearerTokenFileSet():
                 msg = "Stage out requested with tokens, but environment variable is not defined."
                 msg += " Forcing it to use X509 authentication method instead."

--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -29,7 +29,8 @@ class XRDCPImpl(StageOutImpl):
         self.retryPause = 300
         self.xrdfsCmd = "xrdfs"
         self.setAuthX509 = "env X509_USER_PROXY=$X509_USER_PROXY "
-        self.setAuthToken = "env BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat $BEARER_TOKEN_FILE) "
+        # if BEARER_TOKEN_FILE is not set, use /dev/null as a fallback to suppress the error
+        self.setAuthToken = "env BEARER_TOKEN_FILE=$BEARER_TOKEN_FILE BEARER_TOKEN=$(cat ${BEARER_TOKEN_FILE:-/dev/null}) "
         self.unsetX509 = "X509_USER_PROXY= "
         self.unsetToken = "BEARER_TOKEN_FILE= BEARER_TOKEN= "
         self.debuggingTemplate = "#!/bin/bash\n"


### PR DESCRIPTION
Fixes #12144 
Complement to https://github.com/dmwm/WMCore/pull/12218

#### Status
not-tested

#### Description
The default first stage out attempt has been defined to use tokens, however, this PR adds a check on the bearer token file environment variable. If that var is not defined in the environment, then we switch that stage out to use X509.

Further stage out retries would use the `forceMethod` flag, and in such case we allow token to be used, regardless whether the environment is properly defined or not. For this case, I am inclined to say we should not even try - but for now I am keeping the same logic that was inserted a couple of months ago.

I have also fixed it such that the `cat` command no longer hangs on an unset BEARER_TOKEN_FILE environment variable 
```
[dmwm@5f6703bd25f7 WMCore]$ echo "BEARER_TOKEN=$(cat ${BEARER_TOKEN_FILE:-/dev/null})"
BEARER_TOKEN=
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None