### PR TITLE
provide necessary checks to look-up valid process ID status

### DIFF
--- a/bin/wmcoreD
+++ b/bin/wmcoreD
@@ -364,6 +364,10 @@ def checkProcessThreads(component, compDir):
 
     # Check if process is running
     processRunning = psutil.pid_exists(int(pid))
+    if not processRunning:
+        msg = f"Component:{component} with PID={pid} is no longer available on OS"
+        print(msg)
+        return
 
     # Check if threads are running
     runningThreads = []


### PR DESCRIPTION
Fixes #12386 

#### Status
ready

#### Description
Adjust codebase to properly look-up valid process ID status even if process dies on OS.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12302

#### External dependencies / deployment changes
