### PR TITLE
Remove instances of nose and replace with pytest equivalencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wmcore"
+dynamic = ["version"]
+authors = [
+    { name="CMS DMWM Group", email="hn-cms-wmDevelopment@cern.ch" },
+]
+description = "Core libraries for Workload Management Packages"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = []
+license = { file = "LICENSE" }
+
+[project.urls]
+Documentation = "https://cms-wmcore.docs.cern.ch"
+Source = "https://github.com/dmwm/WMCore"
+Issues = "https://github.com/dmwm/WMCore/issues"
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: marks integration tests",
+  "lifecycle",
+  "performance",
+  "workerNodeTest",
+  "cvmfs"
+]
+testpaths = [
+  "test/python"
+]
+norecursedirs = "test/python/WMStats"
+python_files = "*_t.py"
+pythonpath = [
+  "src/python"
+]
+
+[tool.setuptools.packages.find]
+where = [
+  "src/python"
+]

--- a/src/python/WMQuality/Markers.py
+++ b/src/python/WMQuality/Markers.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+noproxy = pytest.mark.skipif(
+    os.environ.get('X509_USER_PROXY', None),
+    reason='Only run if an X509 proxy is present'
+)

--- a/src/python/WMQuality/TestInit.py
+++ b/src/python/WMQuality/TestInit.py
@@ -67,6 +67,7 @@ class TestInit(object):
     initialize their default environment so to
     minimize code duplication.
     """
+    __test__ = False
 
     def __init__(self, testClassName = "Unknown Class"):
         self.testClassName = testClassName

--- a/test/python/Integration_t/ACDCLifeCycle_t.py
+++ b/test/python/Integration_t/ACDCLifeCycle_t.py
@@ -2,9 +2,9 @@ import os
 import unittest
 from json import loads
 
-import nose
+import pytest
+
 from Integration_t.RequestLifeCycleBase_t import RequestLifeCycleBase_t, recordException
-from nose.plugins.attrib import attr
 
 from WMCore.ACDC.DataCollectionService import DataCollectionService
 from WMCore.Database.CMSCouch import Database
@@ -24,7 +24,7 @@ class ACDCLifeCycle_t(RequestLifeCycleBase_t, unittest.TestCase):
                         'Requestor' : 'integration', 'Group' : 'DMWM'
                     }
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test06UploadACDC(self):
         # get previous request we can piggyback on
@@ -34,7 +34,7 @@ class ACDCLifeCycle_t(RequestLifeCycleBase_t, unittest.TestCase):
                 self.__class__.requestParams['OriginalRequestName'] = request
                 break
         else:
-            raise nose.SkipTest("no suitable request in reqmgr to resubmit")
+            raise pytest.skip("no suitable request in reqmgr to resubmit")
 
         self.__class__.requestParams['InitialTaskPath'] = self.__class__.requestParams['InitialTaskPath'] % self.__class__.requestParams['OriginalRequestName']
         self.__class__.requestParams['ACDCServer'] = self.__class__.endpoint + '/couchdb'

--- a/test/python/Integration_t/RequestCancelation_t.py
+++ b/test/python/Integration_t/RequestCancelation_t.py
@@ -3,8 +3,8 @@ from Integration_t.RequestLifeCycleBase_t import RequestLifeCycleBase_t
 
 import time
 import unittest
-import nose
-from nose.plugins.attrib import attr
+
+import pytest
 
 
 class RequestCancellation_t(RequestLifeCycleBase_t, unittest.TestCase):
@@ -18,18 +18,18 @@ class RequestCancellation_t(RequestLifeCycleBase_t, unittest.TestCase):
                     }
 
     # instead of checking its running cancel it.
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     def test60CancelRequest(self):
         """Cancel workflow"""
         self.__class__.reqmgr.reportRequestStatus(self.__class__.request_name, 'aborted')
         self.__class__.request = self.__class__.reqmgr.getRequest(self.__class__.request_name)
         self.assertEqual(self.__class__.request['RequestStatus'], 'aborted')
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     def test70WorkQueueFinished(self):
         """Request canceled in workqueue"""
         if not self.__class__.request_name:
-            raise nose.SkipTest
+            raise pytest.skip()
         start = time.time()
         while True:
             request = [x for x in self.__class__.workqueue.getElementsCountAndJobsByWorkflow() if \
@@ -41,11 +41,11 @@ class RequestCancellation_t(RequestLifeCycleBase_t, unittest.TestCase):
                 raise RuntimeError('timeout waiting for request to finish')
             time.sleep(15)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     def test80RequestFinished(self):
         """Request canceled"""
         if not self.__class__.request_name:
-            raise nose.SkipTest
+            raise pytest.skip()
         start = time.time()
         while True:
             self.__class__.request = self.__class__.reqmgr.getRequest(self.__class__.request_name)

--- a/test/python/Integration_t/RequestLifeCycleBase_t.py
+++ b/test/python/Integration_t/RequestLifeCycleBase_t.py
@@ -7,8 +7,8 @@ from WMCore.Services.WorkQueue.WorkQueue import WorkQueue
 from WMCore.Cache.WMConfigCache import ConfigCache
 from WMCore.WMBase import getTestBase
 
-import nose
-from nose.plugins.attrib import attr
+import pytest
+
 import time
 import os
 import importlib
@@ -39,7 +39,7 @@ class RequestLifeCycleBase_t(object):
     @recordException
     def setUp(self):
         if self.__class__._failure_detected:
-            raise nose.SkipTest
+            raise pytest.skip()
         # simple ping check - check reqmgr up
         tries = 0
         while True:
@@ -50,7 +50,7 @@ class RequestLifeCycleBase_t(object):
             except:
                 tries += 1
                 if tries >= 3:
-                    raise nose.SkipTest("Unable to contact reqmgr")
+                    raise pytest.skip("Unable to contact reqmgr")
                 time.sleep(15)
 
     def _configCacheId(self, label):
@@ -87,13 +87,13 @@ class RequestLifeCycleBase_t(object):
                 config[field] = self._convertLabelsToId(config[field])
         return config
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test05InjectConfigs(self):
         """Inject configs to cache"""
         self.__class__.requestParams = self._convertLabelsToId(self.__class__.requestParams)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test10InjectRequest(self):
         """Can inject a request"""
@@ -114,7 +114,7 @@ class RequestLifeCycleBase_t(object):
         self.__class__.request = self.__class__.reqmgr.getRequest(self.__class__.request_name)
         self.assertEqual(self.__class__.request['RequestStatus'], 'new')
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test20ApproveRequest(self):
         """Approve request"""
@@ -122,7 +122,7 @@ class RequestLifeCycleBase_t(object):
         self.__class__.request = self.__class__.reqmgr.getRequest(self.__class__.request_name)
         self.assertEqual(self.__class__.request['RequestStatus'], 'assignment-approved')#
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test30AssignRequest(self):
         """Assign request"""
@@ -131,12 +131,12 @@ class RequestLifeCycleBase_t(object):
         self.__class__.request = self.reqmgr.getRequest(self.__class__.request_name)
         self.assertEqual(self.__class__.request['RequestStatus'], 'assigned')
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test40WorkQueueAcquires(self):
         """WorkQueue picks up request"""
         if not self.__class__.request_name:
-            raise nose.SkipTest
+            raise pytest.skip()
         start = time.time()
         while True:
             workqueue = self.reqmgr.getWorkQueue(request = self.__class__.request_name)
@@ -152,14 +152,14 @@ class RequestLifeCycleBase_t(object):
                 raise RuntimeError('timeout waiting for workqueue to acquire')
             time.sleep(15)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test50AgentAcquires(self):
         """Elements acquired by agent"""
         # skip if request already running
         self.__class__.request = self.__class__.reqmgr.getRequest(self.__class__.request_name)
         if self.__class__.request['RequestStatus'] == 'running':
-            raise nose.SkipTest
+            raise pytest.skip()
         start = time.time()
         while True:
             request = [x for x in self.__class__.workqueue.getElementsCountAndJobsByWorkflow() if \
@@ -171,7 +171,7 @@ class RequestLifeCycleBase_t(object):
             time.sleep(15)
         self.assertTrue([x for x in request if x['status'] in ('Acquired', 'Running')])
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test60RequestRunning(self):
         """Request running"""
@@ -188,7 +188,7 @@ class RequestLifeCycleBase_t(object):
                 raise RuntimeError('timeout waiting for request to run')
             time.sleep(15)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test70WorkQueueFinished(self):
         """Request completed in workqueue"""
@@ -203,7 +203,7 @@ class RequestLifeCycleBase_t(object):
                 raise RuntimeError('timeout waiting for request to finish')
             time.sleep(15)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test80RequestFinished(self):
         """Request completed"""
@@ -217,7 +217,7 @@ class RequestLifeCycleBase_t(object):
                 raise RuntimeError('timeout waiting for request to finish')
             time.sleep(15)
 
-    @attr("lifecycle")
+    @pytest.mark.lifecycle
     @recordException
     def test90RequestCloseOut(self):
         """Closeout request"""

--- a/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
+++ b/test/python/WMComponent_t/DBS3Buffer_t/DBSUpload_t.py
@@ -10,13 +10,14 @@ from __future__ import division
 
 import json
 import os
+from tempfile import mkstemp
 import threading
 import time
 import unittest
-from tempfile import mkstemp
+
+import pytest
 
 from dbs.apis.dbsClient import DbsApi
-from nose.plugins.attrib import attr
 
 from WMComponent.DBS3Buffer.DBSBufferBlock import DBSBufferBlock
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
@@ -335,7 +336,7 @@ class DBSUploadTest(unittest.TestCase):
                                                MaxEvents, MaxSize)
         return workflowID
 
-    @attr("integration")
+    @pytest.mark.integration
     def testBasicUpload(self):
         """
         _testBasicUpload_
@@ -387,7 +388,7 @@ class DBSUploadTest(unittest.TestCase):
         self.verifyData(childFiles[0]["datasetPath"], childFiles)
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testDualUpload(self):
         """
         _testDualUpload_

--- a/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
+++ b/test/python/WMComponent_t/ErrorHandler_t/ErrorHandler_t.py
@@ -13,10 +13,11 @@ import threading
 import time
 import unittest
 
+import pytest
+
 from Utils.PythonVersion import PY3
 
 from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
-from nose.plugins.attrib import attr
 
 import WMCore.WMBase
 from WMComponent.ErrorHandler.ErrorHandlerPoller import ErrorHandlerPoller
@@ -492,7 +493,7 @@ class ErrorHandlerTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testZ_Profile(self):
         """
         _testProfile_

--- a/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
+++ b/test/python/WMComponent_t/JobAccountant_t/JobAccountant_t.py
@@ -14,7 +14,7 @@ import time
 import unittest
 import logging
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.WMBase
 from WMComponent.DBS3Buffer.DBSBufferDataset import DBSBufferDataset
@@ -1280,7 +1280,8 @@ class JobAccountantTest(EmulatedUnitTestCase):
         inputFileset.commit()
         return
 
-    @attr('performance', 'integration')
+    @pytest.mark.performance
+    @pytest.mark.integration
     def testOneProcessLoadTest(self):
         """
         _testOneProcessLoadTest_

--- a/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
+++ b/test/python/WMComponent_t/JobArchiver_t/JobArchiver_t.py
@@ -13,7 +13,7 @@ import threading
 import unittest
 from subprocess import PIPE, Popen
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMComponent.JobArchiver.JobArchiverPoller import JobArchiverPoller
 from WMCore.DAOFactory import DAOFactory
@@ -245,7 +245,7 @@ class JobArchiverTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testSpeedTest(self):
         """
         _SpeedTest_

--- a/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
+++ b/test/python/WMComponent_t/JobCreator_t/JobCreator_t.py
@@ -16,10 +16,11 @@ import threading
 import time
 import unittest
 
+import pytest
+
 from Utils.PythonVersion import PY3
 
 from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
-from nose.plugins.attrib import attr
 
 from WMComponent.JobCreator.JobCreatorPoller import JobCreatorPoller, capResourceEstimates
 from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
@@ -383,7 +384,9 @@ class JobCreatorTest(EmulatedUnitTestCase):
         self.assertEqual(job['physicsTaskType'], None)
 
         return
-    @attr('performance', 'integration')
+
+    @pytest.mark.performance
+    @pytest.mark.integration
     def testProfilePoller(self):
         """
         Profile your performance
@@ -418,7 +421,7 @@ class JobCreatorTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testProfileWorker(self):
         """
         Profile where the work actually gets done
@@ -454,7 +457,7 @@ class JobCreatorTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testHugeTest(self):
         """
         Don't run this one either

--- a/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
+++ b/test/python/WMComponent_t/JobSubmitter_t/JobSubmitter_t.py
@@ -16,10 +16,11 @@ import threading
 import time
 import unittest
 
+import pytest
+
 from Utils.PythonVersion import PY3
 
 from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
-from nose.plugins.attrib import attr
 
 from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
 from WMCore.Agent.HeartbeatAPI import HeartbeatAPI
@@ -926,7 +927,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
         result = getJobsAction.execute(state='created', jobType="Processing")
         self.assertEqual(len(result), 0)
 
-    @attr('integration')
+    @pytest.mark.integration
     def testF_PollerProfileTest(self):
         """
         _testF_PollerProfileTest_
@@ -977,7 +978,7 @@ class JobSubmitterTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testMemoryProfile(self):
         """
         _testMemoryProfile_

--- a/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
+++ b/test/python/WMComponent_t/JobTracker_t/JobTracker_t.py
@@ -17,7 +17,8 @@ import getpass
 import time
 import cProfile
 import pstats
-from nose.plugins.attrib import attr
+
+import pytest
 
 import WMCore.WMInit
 from WMCore.DAOFactory    import DAOFactory
@@ -288,9 +289,7 @@ class JobTrackerTest(EmulatedUnitTestCase):
 
         return testJobGroup
 
-
-
-    @attr('integration')
+    @pytest.mark.integration
     def testA_CondorTest(self):
         """
         _CondorTest_
@@ -441,7 +440,7 @@ class JobTrackerTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testB_ReallyLongTest(self):
         """
         _ReallyLongTest_

--- a/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
+++ b/test/python/WMComponent_t/RetryManager_t/RetryManager_t.py
@@ -13,7 +13,8 @@ import os.path
 import threading
 import time
 import unittest
-from nose.plugins.attrib import attr
+
+import pytest
 
 import WMCore.WMBase
 from WMComponent.RetryManager.RetryManagerPoller import RetryManagerPoller
@@ -966,7 +967,7 @@ class RetryManagerTest(EmulatedUnitTestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testZ_Profile(self):
         """
         _Profile_

--- a/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
+++ b/test/python/WMComponent_t/TaskArchiver_t/TaskArchiver_t.py
@@ -16,8 +16,9 @@ import threading
 import time
 import unittest
 
+import pytest
+
 from WMCore_t.WMSpec_t.TestSpec import createTestWorkload
-from nose.plugins.attrib import attr
 
 import WMCore.WMBase
 from WMComponent.TaskArchiver.CleanCouchPoller import CleanCouchPoller
@@ -658,7 +659,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
                 '8020'], 0)
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testC_Profile(self):
         """
         _Profile_
@@ -685,7 +686,7 @@ class TaskArchiverTest(EmulatedUnitTestCase):
         p.print_stats()
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testD_Timing(self):
         """
         _Timing_

--- a/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
+++ b/test/python/WMCore_t/ACDC_t/DataCollectionService_t.py
@@ -10,9 +10,9 @@ Copyright (c) 2010 Fermilab. All rights reserved.
 from builtins import range
 import unittest
 
-from Utils.PythonVersion import PY3
+import pytest
 
-from nose.plugins.attrib import attr
+from Utils.PythonVersion import PY3
 
 from WMCore.ACDC.DataCollectionService import DataCollectionService, mergeFilesInfo
 from WMCore.DataStructs.File import File
@@ -450,7 +450,7 @@ class DataCollectionService_t(unittest.TestCase):
 
         return testJob
 
-    @attr('integration')
+    @pytest.mark.integration
     def testFailedJobsUniqueWf(self):
         """
         Performance test of failedJobs with all failed jobs belonging
@@ -464,7 +464,7 @@ class DataCollectionService_t(unittest.TestCase):
         dcs.failedJobs(loadList)
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testFailedJobsScrambledWf(self):
         """
         Performance test of failedJobs where jobs belong to 10 different

--- a/test/python/WMCore_t/Agent_t/Harness_t.py
+++ b/test/python/WMCore_t/Agent_t/Harness_t.py
@@ -10,7 +10,7 @@ import threading
 import time
 import unittest
 
-import nose
+import pytest
 
 from WMCore.Agent.Daemon.Details import Details
 from WMCore.Database.Transaction import Transaction
@@ -40,8 +40,8 @@ class HarnessTest(unittest.TestCase):
         """
         self.testInit.clearDatabase()
 
+    @pytest.mark.skip
     def testB(self):
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         self.tempDir = self.testInit.generateWorkDir(config)
         config.component_("TestComponent")
@@ -83,8 +83,8 @@ class HarnessTest(unittest.TestCase):
             errorMsg = str(ex)
         self.assertTrue(errorMsg.startswith('Message NonExistingMessageType with payload'))
 
+    @pytest.mark.skip
     def testC(self):
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         self.tempDir = self.testInit.generateWorkDir(config)
         config.component_("TestComponent")
@@ -106,8 +106,8 @@ class HarnessTest(unittest.TestCase):
         details.killWithPrejudice()
         print('Daemon killed')
 
+    @pytest.mark.skip
     def testD(self):
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         config.component_("TestComponent")
         config.TestComponent.logLevel = 'INFO'

--- a/test/python/WMCore_t/Agent_t/TestComponent.py
+++ b/test/python/WMCore_t/Agent_t/TestComponent.py
@@ -29,6 +29,7 @@ class TestComponent(Harness):
     components.
 
     """
+    __test__ = False
 
     def __init__(self, config):
         # call the base class

--- a/test/python/WMCore_t/BossAir_t/BossAir_t.py
+++ b/test/python/WMCore_t/BossAir_t/BossAir_t.py
@@ -7,12 +7,12 @@ from __future__ import print_function
 
 import getpass
 import os.path
+import pickle
 import subprocess
 import threading
 import unittest
-import pickle
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.WMInit
 from WMCore.DAOFactory import DAOFactory
@@ -359,7 +359,7 @@ class BossAirTest(unittest.TestCase):
 
         return jobList
 
-    @attr('integration')
+    @pytest.mark.integration
     def testA_APITest(self):
         """
         _APITest_
@@ -436,7 +436,7 @@ class BossAirTest(unittest.TestCase):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testB_PluginTest(self):
         """
         _PluginTest_

--- a/test/python/WMCore_t/BossAir_t/CondorPluginProfileTest.py
+++ b/test/python/WMCore_t/BossAir_t/CondorPluginProfileTest.py
@@ -10,8 +10,9 @@ import os.path
 import pstats
 import unittest
 
+import pytest
+
 from WMCore_t.BossAir_t.BossAir_t import BossAirTest, getCondorRunningJobs
-from nose.plugins.attrib import attr
 
 from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
 from WMCore.BossAir.BossAirAPI import BossAirAPI
@@ -25,7 +26,7 @@ class CondorPluginProfileTest(BossAirTest):
     Inherit everything from BossAir
     """
 
-    @attr('integration')
+    @pytest.mark.integration
     def testF_WMSMode(self):
         """
         _WMSMode_
@@ -78,7 +79,7 @@ class CondorPluginProfileTest(BossAirTest):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testT_updateJobInfo(self):
         """
         _updateJobInfo_

--- a/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
+++ b/test/python/WMCore_t/BossAir_t/SimpleCondorPlugin_t.py
@@ -11,13 +11,12 @@ from future.utils import viewitems
 
 import os.path
 import re
+from subprocess import Popen, PIPE
 import threading
 import time
 import unittest
-from subprocess import Popen, PIPE
 
-from WMCore_t.BossAir_t.BossAir_t import BossAirTest, getCondorRunningJobs
-from nose.plugins.attrib import attr
+import pytest
 
 from WMComponent.JobSubmitter.JobSubmitterPoller import JobSubmitterPoller
 from WMComponent.JobTracker.JobTrackerPoller import JobTrackerPoller
@@ -25,6 +24,7 @@ from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.BossAir.StatusPoller import StatusPoller
 from WMCore.BossAir.Plugins.SimpleCondorPlugin import activityToType
 from WMCore.JobStateMachine.ChangeState import ChangeState
+from WMCore_t.BossAir_t.BossAir_t import BossAirTest, getCondorRunningJobs
 
 
 class SimpleCondorPluginTest(BossAirTest):
@@ -34,7 +34,7 @@ class SimpleCondorPluginTest(BossAirTest):
     Inherit everything from BossAir
     """
 
-    @attr('integration')
+    @pytest.mark.integration
     def testC_CondorTest(self):
         """
         _CondorTest_
@@ -159,7 +159,7 @@ class SimpleCondorPluginTest(BossAirTest):
         self.assertEqual(len(newJobs), nJobs)
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testD_PrototypeChain(self):
         """
         _PrototypeChain_
@@ -260,7 +260,7 @@ class SimpleCondorPluginTest(BossAirTest):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testE_FullChain(self):
         """
         _FullChain_
@@ -331,7 +331,7 @@ class SimpleCondorPluginTest(BossAirTest):
         self.assertEqual(len(result), nJobs * nSubs)
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testF_WMSMode(self):
         """
         _WMSMode_
@@ -383,7 +383,7 @@ class SimpleCondorPluginTest(BossAirTest):
 
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testT_updateJobInfo(self):
         """
         _updateJobInfo_

--- a/test/python/WMCore_t/Credential_t/MyProxy_t.py
+++ b/test/python/WMCore_t/Credential_t/MyProxy_t.py
@@ -7,13 +7,14 @@ The user Proxy and MyProxy is initialized in testCreateMyProxy method and they a
 """
 from __future__ import division
 
-import unittest
-import os
 import logging
 import logging.config
+import os
 import time
+import unittest
 
-from nose.plugins.attrib import attr
+import pytest
+
 from WMCore.Credential.Proxy import Proxy, myProxyEnvironment
 
 # You may have to change these variables to run in a local environment
@@ -53,7 +54,7 @@ class MyProxyTest(unittest.TestCase):
         """
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testAAACreateMyProxy( self ):
         """
         Test if delegate method create correctly the MyProxy.
@@ -63,7 +64,7 @@ class MyProxyTest(unittest.TestCase):
         valid = self.proxy.checkMyProxy( )
         self.assertTrue(valid, 'Could not create MyProxy')
 
-    @attr("integration")
+    @pytest.mark.integration
     def testDelegateServer( self ):
         """
         Test if delegate method create MyProxy and delegate
@@ -73,7 +74,7 @@ class MyProxyTest(unittest.TestCase):
         valid = self.proxy.checkMyProxy( checkRenewer = True )
         self.assertTrue(valid)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testCheckMyProxy( self ):
         """
         Test if checkMyProxy checks correctly the MyProxy validity.
@@ -81,7 +82,7 @@ class MyProxyTest(unittest.TestCase):
         valid = self.proxy.checkMyProxy( )
         self.assertTrue(valid)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testRenewMyProxy( self ):
         """
         Test if renewMyProxy method renews correctly the MyProxy.
@@ -91,7 +92,7 @@ class MyProxyTest(unittest.TestCase):
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath )
         self.assertEqual(int(int(timeLeft) // 3600), 167)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testRenewMyProxyForServer( self ):
         """
         Renew MyProxy which the retrieval is delegated to a server.
@@ -102,7 +103,7 @@ class MyProxyTest(unittest.TestCase):
         timeLeft = self.proxy.getMyProxyTimeLeft( proxy = self.proxyPath, serverRenewer = True )
         self.assertEqual(int(int(timeLeft) // 3600), 167)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testMyProxyEnvironment(self):
         """
         Test the myProxyEnvironment context manager

--- a/test/python/WMCore_t/Credential_t/Proxy_t.py
+++ b/test/python/WMCore_t/Credential_t/Proxy_t.py
@@ -16,7 +16,8 @@ import logging.config
 import time
 import subprocess
 
-from nose.plugins.attrib import attr
+import pytest
+
 from WMCore.Credential.Proxy import Proxy
 from Utils.PythonVersion import PY3
 from Utils.Utilities import decodeBytesToUnicode
@@ -87,7 +88,7 @@ class ProxyTest(unittest.TestCase):
         stdout = decodeBytesToUnicode(stdout) if PY3 else stdout
         return stdout[0:-1]
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetUserCertEnddate( self ):
         """
         Test if getTimeLeft method returns correctly the proxy time left.
@@ -97,7 +98,7 @@ class ProxyTest(unittest.TestCase):
         daysleft = self.proxy.getUserCertEnddate(openSSL=False)
         self.assertEqual(daysleft, 58) #set this as the number of days left in .globus/usercert.pem
 
-    @attr("integration")
+    @pytest.mark.integration
     def testAAACreateProxy( self ):
         """
         Test if create method creates correctly the proxy.
@@ -109,7 +110,7 @@ class ProxyTest(unittest.TestCase):
         proxyPath = self.proxy.getProxyFilename()
         self.assertTrue(os.path.exists(proxyPath))
 
-    @attr("integration")
+    @pytest.mark.integration
     def testCheckProxyTimeLeft( self ):
         """
         Test if getTimeLeft method returns correctly the proxy time left.
@@ -117,7 +118,7 @@ class ProxyTest(unittest.TestCase):
         timeLeft = self.proxy.getTimeLeft()
         self.assertEqual(int(int(timeLeft) // 3600), 191)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testRenewProxy( self ):
         """
         Test if the renew method renews correctly the user proxy.
@@ -128,7 +129,7 @@ class ProxyTest(unittest.TestCase):
         timeLeft = self.proxy.getTimeLeft()
         self.assertEqual(int(int(timeLeft) // 3600), 191)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testDestroyProxy(self ):
         """
         Test the proxy destroy method.
@@ -139,7 +140,7 @@ class ProxyTest(unittest.TestCase):
         # Create the proxy after the destroy
         self.proxy.create()
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetSubject(self):
         """
         _testGetSubject_
@@ -150,7 +151,7 @@ class ProxyTest(unittest.TestCase):
                          "Error: Wrong subject.")
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetUserName( self ):
         """
         _testGetUserName_
@@ -163,7 +164,7 @@ class ProxyTest(unittest.TestCase):
                          "Error: User name is wrong: |%s|\n|%s|" % (user, identity))
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testCheckAttribute( self ):
         """
         Test if the checkAttribute  method checks correctly the attributes validity.
@@ -171,7 +172,7 @@ class ProxyTest(unittest.TestCase):
         valid = self.proxy.checkAttribute( )
         self.assertTrue(valid)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testCheckTimeLeft( self ):
         """
         Test if the check method checks correctly the proxy validity.
@@ -179,7 +180,7 @@ class ProxyTest(unittest.TestCase):
         valid = self.proxy.check( self.proxyPath )
         self.assertTrue(valid)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testVomsRenewal( self ):
         """
         Test if vomsExtensionRenewal method renews correctly the voms-proxy.
@@ -191,7 +192,7 @@ class ProxyTest(unittest.TestCase):
         vomsTimeLeft = self.proxy.getVomsLife( proxyPath )
         self.assertEqual(int(int(vomsTimeLeft) // 3600), 191)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testElevateAttribute( self ):
         """
         Test if the vomsExtensionRenewal method elevate last attributes given.
@@ -203,7 +204,7 @@ class ProxyTest(unittest.TestCase):
         # Restore the original configuration of the proxy
         self.proxy.create()
 
-    @attr("integration")
+    @pytest.mark.integration
     def testUserGroupInProxy( self ):
         """
         Test if getUserAttributes method returns correctly the user group.
@@ -211,14 +212,14 @@ class ProxyTest(unittest.TestCase):
         self.assertTrue(self.proxy.group, 'No group set. Testing incomplete.')
         self.assertEqual(self.proxy.group, self.getUserAttributes().split('\n')[0].split('/')[2])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testUserRoleInProxy( self ):
         """
         Test if getUserAttributes method returns correctly the user role.
         """
         self.assertEqual(self.proxy.role, self.getUserAttributes().split('\n')[0].split('/')[3].split('=')[1])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetAttributes( self ):
         """
         Test getAttributeFromProxy method.
@@ -240,7 +241,7 @@ class ProxyTest(unittest.TestCase):
         #test with the allAttributes flag
         self.assertTrue(self.proxy.getAttributeFromProxy(proxyPath, allAttributes=True)>1)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetUserGroupAndRole( self ):
         """
         Test GetUserGroupAndRoleFromProxy method.
@@ -254,7 +255,7 @@ class ProxyTest(unittest.TestCase):
             self.assertEqual(self.proxy.getUserGroupAndRoleFromProxy(proxyPath)[0], self.dict['group'])
             self.assertEqual(self.proxy.getUserGroupAndRoleFromProxy(proxyPath)[1], role)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetAllUserGroups( self ):
         """
         Test GetAllUserGroups method.

--- a/test/python/WMCore_t/Credential_t/SimpleMyProxy_t.py
+++ b/test/python/WMCore_t/Credential_t/SimpleMyProxy_t.py
@@ -11,7 +11,8 @@ import os
 import logging
 import re
 
-from nose.plugins.attrib import attr
+import pytest
+
 from WMCore.Credential.SimpleMyProxy import SimpleMyProxy
 
 MYPROXYSERVER = os.environ.get('MYPROXY_SERVER', 'myproxy.cern.ch')
@@ -46,7 +47,7 @@ class SimpleMyProxyTest(unittest.TestCase):
         """
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testgetMyProxyInfo(self):
         """
         Test if it's possible to get myproxy information
@@ -59,7 +60,7 @@ class SimpleMyProxyTest(unittest.TestCase):
         assert 'end' in myproxyinfo
         assert myproxyinfo['end'] > myproxyinfo['start']
 
-    @attr("integration")
+    @pytest.mark.integration
     def testgetMyProxy(self):
         """
         Test if it is possible to retrieve a proxy from an existing myproxy

--- a/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
+++ b/test/python/WMCore_t/Database_t/RotatingDatabase_t.py
@@ -1,11 +1,11 @@
 from builtins import range
-import unittest
+from datetime import timedelta
 import os
 import sys
-from datetime import timedelta
 from time import sleep
+import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.Database.CMSCouch import RotatingDatabase, CouchServer, CouchNotFoundError
 
@@ -48,7 +48,7 @@ class RotatingDatabaseTest(unittest.TestCase):
 
     # This test repeatably inserts either 20 or 25 documents into couch.
     # Disabled until it's stable
-    @attr("integration")
+    @pytest.mark.integration
     def testArchive(self):
         """
         Test that archiving views works
@@ -95,7 +95,7 @@ class RotatingDatabaseTest(unittest.TestCase):
         self.assertEqual(0, len(self.db.archived_dbs()))
         self.assertFalse(archived[0] in self.server.listDatabases())
 
-    @attr("integration")
+    @pytest.mark.integration
     def testCycle(self):
         """
         Test that committing data to different databases happens

--- a/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/JobSplitting_t/FileBased_t.py
@@ -5,9 +5,6 @@ _FileBased_t_
 File based splitting test.
 """
 
-
-
-
 from builtins import range
 import unittest
 

--- a/test/python/WMCore_t/MicroService_t/Tools_t/Common_t.py
+++ b/test/python/WMCore_t/MicroService_t/Tools_t/Common_t.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function
 import json
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.MicroService.Tools.Common import (dbsInfo, getEventsLumis, findParent,
                                               hasHTTPFailed, isRelVal)
@@ -23,7 +23,7 @@ class CommonTest(unittest.TestCase):
                          '/ZMM_14TeV/Summer12-DESIGN42_V17_SLHCTk-v1/GEN-SIM']
         self.child = ['/SingleElectron/Run2016B-18Apr2017_ver2-v1/AOD']
 
-    @attr("integration")
+    @pytest.mark.integration
     def testDbsInfo(self):
         "Test function for dbsInfo()"
         datasetBlocks, datasetSizes, datasetTransfers = dbsInfo(self.datasets, self.dbsUrl)
@@ -35,7 +35,7 @@ class CommonTest(unittest.TestCase):
         self.assertEqual(expect, sizes)
         self.assertEqual(len(self.datasets), len(datasetTransfers))
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetEventsLumis(self):
         "Test function for getEventsLumis()"
         totEvts = totLumis = 0
@@ -49,7 +49,7 @@ class CommonTest(unittest.TestCase):
         expect = 16 + 0
         self.assertEqual(expect, totLumis)
 
-    @attr("integration")
+    @pytest.mark.integration
     def test_findParent(self):
         "Test function for findParent()"
         parents = findParent(self.child, self.dbsUrl)

--- a/test/python/WMCore_t/Misc_t/Config_t.py
+++ b/test/python/WMCore_t/Misc_t/Config_t.py
@@ -13,7 +13,7 @@ import logging
 import unittest
 import threading
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.WMInit
 from WMQuality.TestInitCouchApp import TestInitCouchApp as TestInit
@@ -171,7 +171,7 @@ class ConfigTest(unittest.TestCase):
         return
 
 
-    @attr('integration')
+    @pytest.mark.integration
     def testA_WMAgentConfig(self):
         """
         _WMAgentConfig_

--- a/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
+++ b/test/python/WMCore_t/ProcessPool_t/ProcessPool_t.py
@@ -6,7 +6,8 @@ Unit tests for the ProcessPool class.
 
 from builtins import range
 import unittest
-import nose
+
+import pytest
 
 from WMCore.ProcessPool.ProcessPool import ProcessPool
 from WMQuality.TestInit import TestInit
@@ -32,12 +33,12 @@ class ProcessPoolTest(unittest.TestCase):
         self.testInit.clearDatabase()
         return
 
+    @pytest.mark.skip
     def testA_ProcessPool(self):
         """
         _testProcessPool_
 
         """
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         config.Agent.useHeartbeat = False
         self.testInit.generateWorkDir(config)
@@ -58,12 +59,12 @@ class ProcessPoolTest(unittest.TestCase):
 
         return
 
+    @pytest.mark.skip
     def testB_ProcessPoolStress(self):
         """
         _testProcessPoolStress_
 
         """
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         config.Agent.useHeartbeat = False
         self.testInit.generateWorkDir(config)
@@ -93,14 +94,13 @@ class ProcessPoolTest(unittest.TestCase):
 
         return
 
-
+    @pytest.mark.skip
     def testC_MultiPool(self):
         """
         _testMultiPool_
 
         Run a test with multiple workers
         """
-        raise nose.SkipTest
         config = self.testInit.getConfiguration()
         config.Agent.useHeartbeat = False
         self.testInit.generateWorkDir(config)

--- a/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
+++ b/test/python/WMCore_t/ReqMgr_t/Service_t/Auxiliary_t.py
@@ -3,21 +3,20 @@ from __future__ import print_function
 from builtins import range
 from future import standard_library
 
-from WMCore.REST.Error import InvalidUnifiedSchema
-
 standard_library.install_aliases()
 
-import unittest
-import time
 from http.client import HTTPException
+import time
+import unittest
 
-from WMCore_t.ReqMgr_t.TestConfig import config
-from nose.plugins.attrib import attr
-
-from Utils.PythonVersion import PY3
+import pytest
 
 import WMCore
+from WMCore_t.ReqMgr_t.TestConfig import config
+from WMCore.REST.Error import InvalidUnifiedSchema
 from WMQuality.REST.RESTBaseUnitTestWithDBBackend import RESTBaseUnitTestWithDBBackend
+from Utils.PythonVersion import PY3
+
 
 
 class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
@@ -98,7 +97,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "WMAGENT_CONFIG")
         self.assertItemsEqual(list(res[0]["result"][0]), ["key1", "ConfigType"])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testPutWMAgentConfig(self):
         """
         Same as testWMAgentConfig, but test the PUT call in a different unit
@@ -127,7 +126,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "CAMPAIGN_CONFIG")
         self.assertItemsEqual(list(res[0]["result"][0]), ["campName", "keyblah", "ConfigType"])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testPutCampaignConfig(self):
         """
         Same as testCampaignConfig, but test the PUT call in a different unit
@@ -165,7 +164,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertItemsEqual(list(res[0]["result"][0]),
                               ["tiers_to_DDM", "tiers_no_DDM", "tiers_with_no_custodial", "ConfigType"])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testPutUnifiedConfig(self):
         """
         Same as testUnifiedConfig, but test the PUT call in a different unit
@@ -193,7 +192,7 @@ class AuxiliaryTest(RESTBaseUnitTestWithDBBackend):
         self.assertTrue(res[0]["result"][0]["ConfigType"] == "TRANSFER")
         self.assertItemsEqual(list(res[0]["result"][0]), ["key1", "ConfigType"])
 
-    @attr("integration")
+    @pytest.mark.integration
     def testPutTransferInfo(self):
         """
         Same as testTransferInfo, but test the PUT call in a different unit

--- a/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
+++ b/test/python/WMCore_t/Services_t/CRIC_t/CRIC_t.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from Utils.PythonVersion import PY3
 
@@ -47,7 +47,7 @@ class CRICTest(EmulatedUnitTestCase):
         self.assertEqual(cric['cacheduration'], newParams['cacheduration'])
         self.assertEqual(cric['requests'].pycurl, False)
 
-    @attr('integration')
+    @pytest.mark.integration
     def testWhoAmI(self):
         """
         Test user mapping information from the request headers

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSErrors_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSErrors_t.py
@@ -7,8 +7,6 @@ Unit test for the DBSError class.
 
 import unittest
 
-# from nose.plugins.attrib import attr
-
 from dbs.apis.dbsClient import DbsApi
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from WMCore.Services.DBS.DBSErrors import DBSError

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSReader_t.py
@@ -7,8 +7,9 @@ Unit test for the DBS helper class.
 
 import unittest
 
+import pytest
+
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
-from nose.plugins.attrib import attr
 
 from Utils.PythonVersion import PY3
 
@@ -394,7 +395,7 @@ class DBSReaderTest(EmulatedUnitTestCase):
         with self.assertRaises(DBSReaderError):
             self.dbs.listDatasetParents(BLOCK)
 
-    @attr('integration')  # too much data to mock
+    @pytest.mark.integration # too much data to mock
     def testGetParentFilesGivenParentDataset(self):
         """Test the getParentFilesGivenParentDataset method"""
         self.dbs = DBSReader(self.endpoint)
@@ -410,7 +411,7 @@ class DBSReaderTest(EmulatedUnitTestCase):
         self.assertItemsEqual(results[0]['ParentDataset'], PARENT_DATASET)
         self.assertItemsEqual(results[0]['ParentFiles'], ['/store/data/ComissioningHI/Cosmics/RAW/v1/000/180/841/721E482F-A407-E111-8C0C-BCAEC518FF6E.root'])
 
-    @attr('integration')  # too much data to mock
+    @pytest.mark.integration # too much data to mock
     def testListBlocksWithNoParents(self):
         """Test the listBlocksWithNoParents method"""
         self.dbs = DBSReader(self.endpoint)

--- a/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
+++ b/test/python/WMCore_t/Services_t/DBS_t/DBSUtils_t.py
@@ -9,7 +9,7 @@ import time
 import unittest
 import mock
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.Services.DBS.DBSUtils
 from WMCore.Services.DBS.DBSUtils import urlParams, DBSErrors
@@ -36,7 +36,7 @@ class DBSUtilsTest(unittest.TestCase):
         results = urlParams(url)
         self.assertCountEqual(results, {'d': ['1', '2'], 'f': 'bla'})
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetParallelListDatasetFileDetails(self):
         """
         test parallel execution of listDatasetFileDetails DBS API
@@ -75,7 +75,7 @@ class DBSUtilsTest(unittest.TestCase):
         self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
         self.assertTrue(res1 == res2)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetParallelListFileBlockLocation(self):
         """
         test parallel execution of listFileBlockLocation DBS API
@@ -109,7 +109,7 @@ class DBSUtilsTest(unittest.TestCase):
         self.assertTrue(time2 > 0)  # to avoid pyling complaining about not used varaiable
         self.assertTrue(res1 == res2)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetParallelGetParentFilesGivenParentDataset(self):
         """
         test parallel execution of getParentFilesGivenParentDataset DBS API

--- a/test/python/WMCore_t/Services_t/MSPileup_t/MSPileupUtils_t.py
+++ b/test/python/WMCore_t/Services_t/MSPileup_t/MSPileupUtils_t.py
@@ -5,7 +5,7 @@ Unittests for the Services/MSPileup/MSPileupUtils module
 import logging
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMQuality.Emulators.EmulatedUnitTestCase import EmulatedUnitTestCase
 from WMCore.MicroService.MSPileup.DataStructs.MSPileupObj import schema
@@ -29,7 +29,7 @@ class MSPileupUtilsTest(EmulatedUnitTestCase):
         Nothing to be done for this case
         """
 
-    @attr('integration')
+    @pytest.mark.integration
     def testGetPileupDocs(self):
         """
         Test getting pileup docs from testbed.

--- a/test/python/WMCore_t/Services_t/McM_t/McM_t.py
+++ b/test/python/WMCore_t/Services_t/McM_t/McM_t.py
@@ -4,7 +4,9 @@ Test case for McM service
 """
 
 import unittest
-from nose.plugins.attrib import attr
+
+import pytest
+
 from WMCore.Services.McM.McM import McM
 
 prepID = 'BTV-Upg2023SHCAL14DR-00002'
@@ -15,7 +17,7 @@ class McMTest(unittest.TestCase):
     Unit tests for McM Service
     """
 
-    @attr("integration")
+    @pytest.mark.integration
     def testHistory(self):
         """
         Test that the history URL is working
@@ -32,7 +34,7 @@ class McMTest(unittest.TestCase):
 
         self.assertTrue(isAnnounced)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testRequest(self):
         """
         Test that the request URL is working
@@ -43,7 +45,7 @@ class McMTest(unittest.TestCase):
 
         self.assertTrue('total_events' in request)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testHistoryDevelopmentEnv(self):
         """
         Test that the history URL is working.
@@ -63,7 +65,7 @@ class McMTest(unittest.TestCase):
 
         self.assertTrue(isAnnounced)
 
-    @attr("integration")
+    @pytest.mark.integration
     def testRequestDevelopmentEnv(self):
         """
         Test that the request URL is working.

--- a/test/python/WMCore_t/Services_t/Requests_t.py
+++ b/test/python/WMCore_t/Services_t/Requests_t.py
@@ -17,7 +17,7 @@ import time
 import unittest
 from http.client import HTTPException
 
-import nose
+import pytest
 
 import WMCore.Services.Requests as Requests
 from WMCore.DataStructs.Job import Job as DataStructsJob
@@ -26,6 +26,7 @@ from WMCore.DataStructs.Run import Run
 from WMCore.Services.Requests import JSONRequests
 from WMCore.WMInit import getWMBASE
 from WMQuality.TestInit import TestInit
+from WMQuality.Markers import noproxy
 from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
 from WMQuality.WebTools.RESTServerSetup import DefaultConfig
 
@@ -252,11 +253,13 @@ class testJSONRequests(unittest.TestCase):
 
 
 class TestRequests(unittest.TestCase):
+
+    @noproxy
     def testGetKeyCert(self):
         """test existance of key/cert"""
         proxy = os.environ.get('X509_USER_PROXY')
         if not proxy:
-            raise nose.SkipTest('Only run if an X509 proxy is present')
+            raise pytest.skip('Only run if an X509 proxy is present')
         os.environ.pop('X509_HOST_CERT', None)
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
@@ -266,11 +269,12 @@ class TestRequests(unittest.TestCase):
         self.assertNotEqual(None, key)
         self.assertNotEqual(None, cert)
 
+    @noproxy
     def testSecureWithProxy(self):
         """https with proxy"""
         proxy = os.environ.get('X509_USER_PROXY')
         if not proxy:
-            raise nose.SkipTest('Only run if an X509 proxy is present')
+            raise pytest.skip('Only run if an X509 proxy is present')
         os.environ.pop('X509_HOST_CERT', None)
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
@@ -281,11 +285,12 @@ class TestRequests(unittest.TestCase):
         self.assertNotEqual(out[0].find('passed basic validation'), -1)
         self.assertNotEqual(out[0].find('certificate is a proxy'), -1)
 
+    @noproxy
     def testSecureWithProxy_with_pycurl(self):
         """https with proxy with pycurl"""
         proxy = os.environ.get('X509_USER_PROXY')
         if not proxy:
-            raise nose.SkipTest('Only run if an X509 proxy is present')
+            raise pytest.skip('Only run if an X509 proxy is present')
         os.environ.pop('X509_HOST_CERT', None)
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
@@ -317,11 +322,12 @@ class TestRequests(unittest.TestCase):
         # we should get an html page in response
         self.assertNotEqual(out[0].find('html'), -1)
 
+    @noproxy
     def testSecureOddPort(self):
         """https with odd port"""
         proxy = os.environ.get('X509_USER_PROXY')
         if not proxy:
-            raise nose.SkipTest('Only run if an X509 proxy is present')
+            raise pytest.skip('Only run if an X509 proxy is present')
         os.environ.pop('X509_HOST_CERT', None)
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)
@@ -331,11 +337,12 @@ class TestRequests(unittest.TestCase):
         self.assertEqual(out[1], 200)
         self.assertNotEqual(out[0].find('passed basic validation'), -1)
 
+    @noproxy
     def testSecureOddPort_with_pycurl(self):
         """https with odd port"""
         proxy = os.environ.get('X509_USER_PROXY')
         if not proxy:
-            raise nose.SkipTest('Only run if an X509 proxy is present')
+            raise pytest.skip('Only run if an X509 proxy is present')
         os.environ.pop('X509_HOST_CERT', None)
         os.environ.pop('X509_HOST_KEY', None)
         os.environ.pop('X509_USER_CERT', None)

--- a/test/python/WMCore_t/Services_t/Rucio_t/RucioConMon_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/RucioConMon_t.py
@@ -7,7 +7,7 @@ Unit tests for RucioConMon WMCore Service class
 
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.Services.RucioConMon.RucioConMon import RucioConMon
 
@@ -17,7 +17,7 @@ class RucioConMonTest(unittest.TestCase):
     Unit tests for RucioConMon Service module
     """
 
-    @attr("integration")
+    @pytest.mark.integration
     def testGetRSEUnmerged(self):
         """
         Test getRSEUnmerged method using both zipped and unzipped requests

--- a/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
+++ b/test/python/WMCore_t/Services_t/Rucio_t/Rucio_t.py
@@ -8,7 +8,7 @@ import os
 from builtins import range
 
 from future.utils import viewitems
-from nose.plugins.attrib import attr
+import pytest
 from rucio.client import Client as testClient
 
 from Utils.PythonVersion import PY3
@@ -173,7 +173,7 @@ class RucioTest(EmulatedUnitTestCase):
         res = self.myRucio.getAccountLimits("any_random_account")
         self.assertEqual(res, {})
 
-    # @attr('integration')
+    #@pytest.mark.integration
     def testWhoAmI(self):
         """
         Test user mapping information from the request headers
@@ -272,7 +272,7 @@ class RucioTest(EmulatedUnitTestCase):
         # resp = self.myRucio.getPFN(site="T2_US_Nebraska", lfns=lfn1, protocol='xrootd')
         # self.assertEqual(resp[lfn1], "davs://xrootd-local.unl.edu:1094/store/test/rucio/int" + lfn1)
 
-    @attr('integration')
+    @pytest.mark.integration
     def testProdGetPFN(self):
         """
         Test `getPFN` method using the production server, hence set
@@ -332,7 +332,7 @@ class RucioTest(EmulatedUnitTestCase):
         res = self.myRucio.listDataRules(DSET)
         self.assertItemsEqual(res, [])
 
-    @attr('integration')
+    @pytest.mark.integration
     def testListDataRules2(self):
         """
         Test `listDataRules` method with data from production
@@ -414,7 +414,7 @@ class RucioTest(EmulatedUnitTestCase):
         resp = self.myRucio.requiresApproval("T1_IT_CNAF_Tape_Input")
         self.assertFalse(resp)
 
-    @attr('integration')  # jenkins cannot access this rucio account
+    @pytest.mark.integration # jenkins cannot access this rucio account
     def testGetPileupLockedAndAvailable(self):
         """
         Test `getPileupLockedAndAvailable` method
@@ -429,7 +429,7 @@ class RucioTest(EmulatedUnitTestCase):
         for block, rses in viewitems(resp):
             self.assertTrue(len(rses) >= 2)
 
-    @attr('integration')  # jenkins cannot access this rucio account
+    @pytest.mark.integration # jenkins cannot access this rucio account
     def testGetDataLockedAndAvailable(self):
         """
         Test `getDataLockedAndAvailable` method

--- a/test/python/WMCore_t/Services_t/Service_t.py
+++ b/test/python/WMCore_t/Services_t/Service_t.py
@@ -4,6 +4,7 @@ from builtins import object
 from future import standard_library
 standard_library.install_aliases()
 
+from http.client import BadStatusLine, IncompleteRead, HTTPException
 from io import BytesIO
 import logging
 import logging.config
@@ -13,10 +14,9 @@ import socket
 import tempfile
 import time
 import unittest
-from http.client import BadStatusLine, IncompleteRead, HTTPException
 
 import cherrypy
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.Services.Requests import Requests
 from WMCore.Services.Service import Service, isfile, cache_expired
@@ -336,7 +336,7 @@ class ServiceTest(unittest.TestCase):
         out = service.refreshCache('shouldntbeused', '/').read()
         self.assertTrue('html' in out)
 
-    @attr("integration")
+    @pytest.mark.integration
     def notestTruncatedResponse(self):
         """
         _TruncatedResponse_
@@ -354,7 +354,7 @@ class ServiceTest(unittest.TestCase):
         cherrypy.engine.exit()
         cherrypy.engine.stop()
 
-    @attr("integration")
+    @pytest.mark.integration
     def notestSlowResponse(self):
         """
         _SlowResponse_
@@ -391,7 +391,7 @@ class ServiceTest(unittest.TestCase):
         myService['requests'] = CrappyRequest('http://bad.com', {})
         self.assertRaises(BadStatusLine, myService.getData, 'foo', '')
 
-    @attr("integration")
+    @pytest.mark.integration
     def notestZ_InterruptedConnection(self):
         """
         _InterruptedConnection_

--- a/test/python/WMCore_t/Storage_t/Plugins_t/SRMV2Impl_t.py
+++ b/test/python/WMCore_t/Storage_t/Plugins_t/SRMV2Impl_t.py
@@ -2,14 +2,15 @@ from __future__ import print_function
 import logging
 logging.basicConfig(level = logging.DEBUG)
 import unittest
+
 from mock import mock
+import pytest
+
 from WMCore.Storage.Plugins.LCGImpl import LCGImpl as ourPlugin
 import WMCore.Storage.Plugins.LCGImpl
+from WMCore.Storage.StageOutError import StageOutError, StageOutFailure
 moduleWeAreTesting = WMCore.Storage.Plugins.LCGImpl
 
-from WMCore.Storage.StageOutError import StageOutError, StageOutFailure
-
-from nose.plugins.attrib import attr
 
 def getPluginObject(mock_os, mock_Popen, localSize, remoteSize):
 
@@ -30,7 +31,7 @@ def getPluginObject(mock_os, mock_Popen, localSize, remoteSize):
 
 class SRMV2ImplTest(unittest.TestCase):
 
-    @attr("integration")
+    @pytest.mark.integration
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
     def testFailSrmCopy(self, mock_os, mock_Popen):
@@ -51,7 +52,7 @@ class SRMV2ImplTest(unittest.TestCase):
                               None)
 
 
-    @attr("integration")
+    @pytest.mark.integration
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
     def testFailOnFileSize(self, mock_os, mock_Popen, localSize=9001, remoteSize=9002):
@@ -69,7 +70,7 @@ class SRMV2ImplTest(unittest.TestCase):
                               None,
                               None)
 
-    @attr("integration")
+    @pytest.mark.integration
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.subprocess.Popen')
     @mock.patch('WMCore.Storage.Plugins.LCGImpl.os')
     def testWin(self, mock_os, mock_Popen, localSize=9001, remoteSize=9001):

--- a/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
+++ b/test/python/WMCore_t/Storage_t/SiteLocalConfig_t.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 import os
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.Storage.SiteLocalConfig import SiteLocalConfig, SiteConfigError
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
@@ -95,7 +95,8 @@ class SiteLocalConfigTest(unittest.TestCase):
                          "Error: Wrong site name.")
 
     # this test requires access to CVMFS
-    @attr("integration")
+    @pytest.mark.integration
+    @pytest.mark.cvmfs
     def testSlcPhedexNodesEqualPhedexApiNodes(self):
         """
         For each site, verify that the stageout node specified in

--- a/test/python/WMCore_t/Storage_t/StageInMgr_t.py
+++ b/test/python/WMCore_t/Storage_t/StageInMgr_t.py
@@ -4,6 +4,8 @@ Created on Nov. 7, 2023 by Duong Nguyen
 import os
 import unittest
 
+import pytest
+
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Storage.SiteLocalConfig import stageOutStr
 from WMCore.Storage.StageInMgr import StageInMgr
@@ -73,6 +75,7 @@ class StageInMgrUnitTest(unittest.TestCase):
         os.putenv('CMS_PATH', os.getcwd())
         os.putenv('SITECONFIG_PATH', os.getcwd())
 
+    @pytest.mark.cvmfs
     def testStageInMgr(self):
         os.environ['SITECONFIG_PATH'] = '/cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL'
         stageInMgr = StageInMgrTest()

--- a/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
+++ b/test/python/WMCore_t/ThreadPool_t/ThreadPool_t.py
@@ -9,21 +9,20 @@ Unit tests for threadpool.
 from __future__ import absolute_import
 from __future__ import print_function
 
-
-
-
 from builtins import str, range
-import unittest
 import threading
 import time
+import unittest
+
+import pytest
 
 from WMCore.ThreadPool.ThreadPool import ThreadPool
-
 from WMQuality.TestInit import TestInit
 
 # local import
 from .Dummy import Dummy
-import nose
+
+
 class ThreadPoolTest(unittest.TestCase):
     """
     _ThreadPool_t_
@@ -52,14 +51,13 @@ class ThreadPoolTest(unittest.TestCase):
 
         self.testInit.clearDatabase()
 
+    @pytest.mark.skip
     def testA(self):
         """
         __testSubscribe__
 
         Test subscription of a component.
         """
-        raise nose.SkipTest
-
         myThread = threading.currentThread()
         # create a 'fake' component that contains a arg dictionary.
         component = Dummy()

--- a/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
+++ b/test/python/WMCore_t/WMBS_t/CursorLeak_t.py
@@ -9,7 +9,7 @@ from builtins import range
 import threading
 import unittest
 
-import nose
+import pytest
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.DataStructs.Run import Run
@@ -52,6 +52,7 @@ class CursorLeakTest(unittest.TestCase):
         """
         self.testInit.clearDatabase()
 
+    @pytest.mark.skip
     def testCursor(self):
         """
         _testCursor_
@@ -65,7 +66,6 @@ class CursorLeakTest(unittest.TestCase):
 
         """
 
-        raise nose.SkipTest
         fileList = []
         parentFile = None
         for i in range(100):
@@ -91,6 +91,7 @@ class CursorLeakTest(unittest.TestCase):
 
         return
 
+    @pytest.mark.skip
     def testLotsOfAncestors(self):
         """
         _testLotsOfAncestors_
@@ -98,7 +99,6 @@ class CursorLeakTest(unittest.TestCase):
         Create a file with 15 parents with each parent having 100 parents to
         verify that the query to return grandparents works correctly.
         """
-        raise nose.SkipTest
         testFileA = File(lfn="/this/is/a/lfnA", size=1024, events=10,
                          checksums={"cksum": "1"}, locations="se1.fnal.gov")
         testFileA.create()

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/FileBased_t.py
@@ -6,20 +6,20 @@ File based splitting test.
 """
 
 
-import unittest
 import threading
+import unittest
 
+
+from WMCore.DAOFactory import DAOFactory
+from WMCore.DataStructs.Run import Run
+from WMCore.JobSplitting.SplitterFactory import SplitterFactory
+from WMCore.Services.UUIDLib import makeUUID
 from WMCore.WMBS.File import File
 from WMCore.WMBS.Fileset import Fileset
 from WMCore.WMBS.Subscription import Subscription
 from WMCore.WMBS.Workflow import Workflow
-from WMCore.DataStructs.Run import Run
-
-from WMCore.DAOFactory import DAOFactory
-from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUIDLib import makeUUID
 from WMQuality.TestInit import TestInit
-#from nose.plugins.attrib import attr
+
 
 class FileBasedTest(unittest.TestCase):
     """

--- a/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
+++ b/test/python/WMCore_t/WMBS_t/JobSplitting_t/MinFileBased_t.py
@@ -23,7 +23,7 @@ from WMCore.DAOFactory                   import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
 from WMCore.Services.UUIDLib                import makeUUID
 from WMQuality.TestInit                  import TestInit
-#from nose.plugins.attrib import attr
+
 
 class FileBasedTest(unittest.TestCase):
     """

--- a/test/python/WMCore_t/WMBase_t.py
+++ b/test/python/WMCore_t/WMBase_t.py
@@ -10,7 +10,7 @@ import os
 import os.path
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.WMBase import getWMBASE, getTestBase
 
@@ -26,7 +26,7 @@ class WMBaseTest(unittest.TestCase):
 
         return
 
-    @attr("integration")
+    @pytest.mark.integration
     def testB_TestBase(self):
         """
         _TestBase_

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DQMUpload_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DQMUpload_t.py
@@ -2,16 +2,17 @@ from __future__ import print_function
 import logging
 from future import standard_library
 standard_library.install_aliases()
-import urllib.request
-
-import unittest
-from nose.plugins.attrib import attr
 
 import os
 from functools import reduce
 from hashlib import md5
+import unittest
+import urllib.request
+
+import pytest
 
 from WMCore.WMSpec.Steps.Executors.DQMUpload import DQMUpload
+
 
 class StepPatch():
     def __init__(self, upload=None):
@@ -28,7 +29,7 @@ class DQMUpload_t(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @attr("integration")
+    @pytest.mark.integration
     def test_upload(self):
         """
         test_upload
@@ -76,7 +77,7 @@ class DQMUpload_t(unittest.TestCase):
         # Dqm-Status-Code == 300 was related to " File name does not match the expected convention"
         self.assertEqual(headers.get("Dqm-Status-Code", None), '100')
 
-    @attr("integration")
+    @pytest.mark.integration
     def test_httppost(self):
         """
         test_httppost

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DeleteFiles_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/DeleteFiles_t.py
@@ -3,8 +3,15 @@ Created on Aug 10, 2010
 
 @author: meloam
 '''
-import unittest
+
+import inspect
+import os.path
 import shutil
+import sys
+import unittest
+
+import pytest
+
 from WMQuality.TestInit import TestInit
 
 from WMCore.WMSpec.WMStep import WMStep
@@ -15,11 +22,6 @@ from WMCore.WMSpec.Steps.Templates.DeleteFiles import DeleteFiles as DeleteTempl
 from WMCore.WMSpec.Steps.Executors.DeleteFiles import DeleteFiles as DeleteExecutor
 from WMCore.WMSpec.Makers.TaskMaker import TaskMaker
 import WMCore.WMSpec.Steps.StepFactory as StepFactory
-
-import os.path
-import sys
-import inspect
-from nose.plugins.attrib import attr
 
 import WMCore_t.WMSpec_t.Steps_t as ModuleLocator
 
@@ -74,7 +76,7 @@ class deleteFileTest(unittest.TestCase):
         step.override.__setattr__('phedex-node','DUMMYPNN')
 
 
-    @attr('integration')
+    @pytest.mark.integration
     def testManualDeleteOld(self):
         self.assertTrue(os.path.exists( os.path.join(self.testDir, 'testfile')))
         self.step.section_('filesToDelete')
@@ -85,7 +87,7 @@ class deleteFileTest(unittest.TestCase):
         self.assertFalse(os.path.exists( os.path.join(self.testDir, 'testfile')))
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testManualDeleteNew(self):
         self.assertTrue(os.path.exists( os.path.join(self.testDir, 'testfile')))
         self.step.section_('filesToDelete')
@@ -97,7 +99,7 @@ class deleteFileTest(unittest.TestCase):
         self.assertFalse(os.path.exists( os.path.join(self.testDir, 'testfile')))
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testJobDeleteOld(self):
         self.assertTrue(os.path.exists( os.path.join(self.testDir, 'testfile')))
         self.setLocalOverride(self.step)
@@ -107,7 +109,7 @@ class deleteFileTest(unittest.TestCase):
         self.assertFalse(os.path.exists( os.path.join(self.testDir, 'testfile')))
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testJobDeleteNew(self):
         self.assertTrue(os.path.exists( os.path.join(self.testDir, 'testfile')))
         self.setLocalOverride(self.step)

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/LogArch_t.py
@@ -23,7 +23,7 @@ import threading
 import time
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.Storage.StageOutError as StageOutError
 import WMCore.WMSpec.Steps.Builders.CMSSW as CMSSWBuilder
@@ -328,7 +328,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         if hasattr(myThread, "factory"):
             myThread.factory = {}
 
-    @attr('integration')
+    @pytest.mark.integration
     def testCPBackendLogArchiveAgainstReportNew(self):
         myReport = Report()
         myReport.unpersist(os.path.join(self.testDir, 'UnitTests', 'WMTaskSpace', 'cmsRun1', 'Report.pkl'))
@@ -343,7 +343,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.testDir, 'hosts')))
         self.assertTrue(os.path.exists(os.path.join(self.testDir, 'test1', 'hosts')))
 
-    @attr('integration')
+    @pytest.mark.integration
     def testCPBackendLogArchiveAgainstReportFailedStepNew(self):
         myReport = Report()
         myReport.unpersist(os.path.join(self.testDir, 'UnitTests', 'WMTaskSpace', 'cmsRun1', 'Report.pkl'))
@@ -359,7 +359,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(self.testDir, 'test1', 'hosts')))
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testCPBackendLogArchiveAgainstReportOld(self):
 
         myReport = Report()
@@ -375,7 +375,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.testDir, 'test1', 'hosts')))
         return
 
-    @attr('integration')
+    @pytest.mark.integration
     def testCPBackendLogArchiveAgainstReportFailedStepOld(self):
         myReport = Report()
         myReport.unpersist(os.path.join(self.testDir, 'UnitTests', 'WMTaskSpace', 'cmsRun1', 'Report.pkl'))
@@ -391,7 +391,7 @@ class otherLogArchiveTexst(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(self.testDir, 'test1', 'hosts')))
         return
 
-    @attr('workerNodeTest')
+    @pytest.mark.workerNodeTest
     def testOnWorkerNodes(self):
         raise RuntimeError
         # Stage a file out, stage it back in, check it, delete it

--- a/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
+++ b/test/python/WMCore_t/WMSpec_t/Steps_t/Executors_t/StageOut_t.py
@@ -24,7 +24,7 @@ import threading
 import time
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 import WMCore.Storage.StageOutError as StageOutError
 import WMCore.WMSpec.Steps.Builders.CMSSW as CMSSWBuilder
@@ -418,7 +418,7 @@ class otherStageOutTexst(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(self.testDir, 'test1', 'hosts')))
         return
 
-    @attr('workerNodeTest')
+    @pytest.mark.workerNodeTest
     def testOnWorkerNodes(self):
         raise RuntimeError
         # Stage a file out, stage it back in, check it, delete it

--- a/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
+++ b/test/python/WMCore_t/WebTools_t/RESTFormat_t.py
@@ -11,7 +11,7 @@ import json
 import unittest
 import logging
 
-from nose.plugins.attrib import attr
+import pytest
 
 from WMCore.WebTools.RESTFormatter import RESTFormatter
 from WMQuality.WebTools.RESTBaseUnitTest import RESTBaseUnitTest
@@ -51,7 +51,7 @@ class RESTFormatTest(RESTBaseUnitTest):
 
     # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
     # Disabling for now
-    @attr("integration")
+    @pytest.mark.integration
     def testEncodedInput(self):
         textType = 'text/plain'
 

--- a/test/python/WMCore_t/WebTools_t/REST_t.py
+++ b/test/python/WMCore_t/WebTools_t/REST_t.py
@@ -10,13 +10,13 @@ TODO: duplicate all direct call tests to ones that use HTTP
 from future import standard_library
 standard_library.install_aliases()
 
-import unittest
-import logging
-import urllib.request, urllib.error
 import json
+import logging
+import unittest
+import urllib.request, urllib.error
 
 from cherrypy import HTTPError
-from nose.plugins.attrib import attr
+import pytest
 from tempfile import NamedTemporaryFile
 
 from WMCore_t.WebTools_t.DummyRESTModel import DummyRESTModel
@@ -317,7 +317,7 @@ class RESTTest(RESTBaseUnitTest):
 
     # This test is flipping back and forth in Jenkins. Perhaps due to port 8888 not being available.
     # Disabling for now
-    @attr("integration")
+    @pytest.mark.integration
     def testDAOBasedHTTP(self):
         """
         Same as testSanitisePass but do it over http and check the returned http
@@ -375,7 +375,7 @@ class RESTTest(RESTBaseUnitTest):
                  '. Returned data: %s' % response[0]
 
     @cherrypySetup(secureConfig)
-    @attr("integration")
+    @pytest.mark.integration
     def testAuthentication(self):
         verb ='PUT'
         url = self.urlbase + 'list1'

--- a/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
+++ b/test/python/WMCore_t/WorkQueue_t/WorkQueueReqMgrInterface_t.py
@@ -6,11 +6,12 @@ WorkQueueRegMgrInterface test
 
 import unittest
 
-from WMCore_t.WorkQueue_t.WorkQueueTestCase import WorkQueueTestCase
-from nose.plugins.attrib import attr
+import pytest
+
 
 from WMCore.WorkQueue.WorkQueue import globalQueue, localQueue
 from WMCore.WorkQueue.WorkQueueReqMgrInterface import WorkQueueReqMgrInterface
+from WMCore_t.WorkQueue_t.WorkQueueTestCase import WorkQueueTestCase
 from WMQuality.Emulators.DataBlockGenerator.Globals import GlobalParams
 from WMQuality.Emulators.ReqMgrClient.ReqMgr import ReqMgr as fakeReqMgr
 
@@ -86,7 +87,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
                             CacheDir=self.testInit.testDir)
         return localQ
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testReqMgrPollerAlgorithm(self):
         """ReqMgr reporting"""
         # don't actually talk to ReqMgr - mock it.
@@ -130,7 +131,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         reqMgrInt(globalQ)
         reqMgr._removeSpecs()
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testReqMgrProgress(self):
         """ReqMgr interaction with block level splitting"""
         globalQ = self.setupGlobalWorkqueue()
@@ -169,7 +170,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         self.assertEqual(reqMgr.status[reqMgr.names[0]], 'completed')
         reqMgr._removeSpecs()
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testInvalidSpec(self):
         """Report invalid spec back to ReqMgr"""
         globalQ = self.setupGlobalWorkqueue()
@@ -190,7 +191,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         self.assertTrue('DBS config error' in reqMgr.msg[reqMgr.names[0]])
         reqMgr._removeSpecs()
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testCancelPickedUp(self):
         """WorkQueue cancels if canceled in ReqMgr"""
         globalQ = self.setupGlobalWorkqueue()
@@ -207,7 +208,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         reqMgrInt(globalQ)
         self.assertEqual(globalQ.status(WorkflowName=reqMgr.names[0])[0]['Status'], 'Canceled')
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testReqMgrWaitTime(self):
         """If running request finished in Reqmgr and no update locally for a long time decalre request done"""
         globalQ = self.setupGlobalWorkqueue()
@@ -236,7 +237,7 @@ class WorkQueueReqMgrInterfaceTest(WorkQueueTestCase):
         reqMgrInt(globalQ)
         self.assertEqual(globalQ.status(WorkflowName=reqMgr.names[0])[0]['Status'], 'Done')
 
-    @attr('integration')  # BROKEN
+    @pytest.mark.integration # BROKEN
     def testReqMgrOpenRequests(self):
         """Check the mechanics of open running requests"""
         # don't actually talk to ReqMgr - mock it.


### PR DESCRIPTION
Fixes #12165 , #12383 

#### Status
In development | not-tested

#### Description
Due to nose 1.3.7 being last updated in 2015 and the nose project is looking for maintainers, we should look to replace nosetest. This PR attempts to replace nose with pytest.

In addition to no maintainers, nose relies on the `imp` module, which does not exist in Python 3.12. This would block our testing to be migrated to Python 3.12.

#### Is it backward compatible (if not, which system it affects?)
NO, not compatible with our existing testing setup.

#### Related PRs

#### External dependencies / deployment changes
Yes, would require switching out nose for pytest in our requirements.txt

In its current state, Jenkins should be failing since Pytest requirement is not installed.
