### PR TITLE
Update checkProxy/restartComponent scripts to use valid domain name

### DIFF
--- a/deploy/checkProxy.py
+++ b/deploy/checkProxy.py
@@ -16,6 +16,7 @@ import socket
 
 
 HOST = socket.gethostname()
+USER = os.getenv('USER')
 
 
 def main(argv):
@@ -40,7 +41,7 @@ def main(argv):
     proxy = os.getenv('X509_USER_PROXY')
     myproxy = False
     verbose = False
-    mail = os.getenv('USER')
+    mail = USER
     sendMail = True
     time = 3
 
@@ -98,10 +99,16 @@ def sendMailNotification(mail, message, proxyInfo='', verbose=False):
     # append proxy info to message
     for line in proxyInfo:
         message += "%s\n" % line
-    # echo %msg | mail -s 'HOST proxy status' MAIL_ADD
-    command = " echo \"%s\" | " % (message)
-    command += "mail -s '%s: Proxy status'" % (HOST)
-    command += " %s" % (mail)
+
+    # retrieve short and domain name to be used in the from-address of the email
+    host_name = HOST.split('.')[0]
+    domain_name = HOST.split('.')[1:]
+    domain_name = '.'.join(domain_name)
+    # echo %msg | mail -s 'HOST proxy status' -r FROM_ADDRESS TO_ADDRESS
+    command = f" echo \"{message}\" | "
+    command += f"mail -s '{HOST}: Proxy status'"
+    command += f" -r {USER}-{host_name}@{domain_name}"
+    command += f" {mail}"
 
     if verbose:
         print("Running email command: {}".format(command))

--- a/deploy/restartComponent.sh
+++ b/deploy/restartComponent.sh
@@ -6,7 +6,10 @@
 # when only one of the threads is down.
 ###
 
-HOST=$(hostname)
+USER=$(whoami)
+FQDN=$(hostname)
+HOST_NAME=$(hostname -s)
+DOMAIN_NAME=$(hostname -d)
 DATENOW=$(date +%s)
 # look-up alert emails from WMA secret file where ALERT_EMAILS may contains multiple emails and spaces, e.g.
 # ALERT_EMAILS="user1@domain.com user2@domain.com" or ALERT_EMAILS = "user1@domain.com user2@domain.com"
@@ -38,7 +41,7 @@ for comp in $comps; do
     echo -e "Restarting component: $comp"
     manage execute-agent wmcoreD --restart --components=$comp
     echo -e "ComponentLog quiet for $INTERVAL secs\n\nTail of the log is:\n$TAIL_LOG" |
-      mail -s "$HOST : $comp restarted" $ALERT_EMAILS
+      mail -s "$FQDN : $comp restarted" -r $USER-$HOST_NAME@$DOMAIN_NAME $ALERT_EMAILS
   fi
 done
 


### PR DESCRIPTION
Fixes #12391 

#### Status
ready

#### Description
Ensure that from-address uses the following pattern: <username>-<short_host_name>@<domain_name>

Hence ensuring these emails are properly delivered (instead of being marked as spam).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None