### PR TITLE
Fix WMAGENT_CONFIG exports

### DIFF
--- a/deploy/deploy-wmagent-venv.sh
+++ b/deploy/deploy-wmagent-venv.sh
@@ -519,6 +519,7 @@ wmaInstall() {
     _addWMCoreVenvVar  WMA_INSTALL_DIR $WMA_CURRENT_DIR/install
     _addWMCoreVenvVar  WMA_CONFIG_DIR $WMA_CURRENT_DIR/config
     _addWMCoreVenvVar  WMA_CONFIG_FILE $WMA_CONFIG_DIR/config.py
+    _addWMCoreVenvVar  WMAGENT_CONFIG $WMA_CONFIG_DIR/config.py
     _addWMCoreVenvVar  WMA_LOG_DIR $WMA_CURRENT_DIR/logs
     _addWMCoreVenvVar  WMA_DEPLOY_DIR $venvPath
     _addWMCoreVenvVar  WMA_MANAGE_DIR $WMA_DEPLOY_DIR/bin


### PR DESCRIPTION
Fix https://github.com/dmwm/WMCore/issues/12307
Fix https://github.com/dmwm/WMCore/issues/12091

#### Status
ready

#### Description
This is a supplementary PR, meant to fix an old standing  minor issue we chose to live with in the past. More precisely - to delay the export of the `WMAGENT_CONFIG` file as late as the execution of the `manage` script. This is no longer needed. And even worse, this is actually a showstopper for many other `wmcoreD` driving actions  we are now trying to do directly from python and is a blocker for: https://github.com/dmwm/WMCore/pull/12382    

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12382

#### External dependencies / deployment changes
PR: https://github.com/dmwm/WMCore/pull/12382
PR: https://github.com/dmwm/CMSKubernetes/pull/1624
Issue: https://github.com/dmwm/WMCore/issues/12091
issue: https://github.com/dmwm/WMCore/issues/12307