### PR TITLE
fix bug checkProxy incompatible

### DIFF
--- a/deploy/checkProxy.py
+++ b/deploy/checkProxy.py
@@ -129,7 +129,7 @@ def processTimeLeft(sendMail, verbose, proxyInfo, time, mail):
         timeLeft = []
         for line in proxyInfo:
             if line.find(b'timeleft') > -1:
-                dateReg = re.compile(b'\d{1,3}[:/]\d{2}[:/]\d{2}')
+                dateReg = re.compile(rb'\d{1,3}[:/]\d{2}[:/]\d{2}')
                 timeLeft = dateReg.findall(line)[0]
                 timeLeft = timeLeft.split(b':')[0]
                 continue


### PR DESCRIPTION
Fixes #12402

#### Status
ready

#### Description
Fixed SyntaxWarning in checkProxy.py by converting the regex pattern to use raw bytes string.

The issue was on line 132 where the pattern `b'\d{1,3}[:/]\d{2}[:/]\d{2}'` was generating a SyntaxWarning because `\d` is not a valid escape sequence in Python strings. Changed it to `rb'\d{1,3}[:/]\d{2}[:/]\d{2}'` to use a raw bytes string, which treats backslashes literally and preserves the intended regex pattern.

This eliminates the warning while maintaining identical functionality.

#### Is it backward compatible (if not, which system it affects?)
**YES** 

#### Related PRs
N/A - This is a standalone bug fix.

#### External dependencies / deployment changes

