### PR TITLE
Configurable memory requirement for harvesting tasks

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/Express.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/Express.py
@@ -230,7 +230,8 @@ class ExpressWorkloadFactory(StdBase):
                     self.addDQMHarvestTask(mergeTask, "Merged",
                                            uploadProxy=self.dqmUploadProxy,
                                            periodic_harvest_interval=self.periodicHarvestInterval,
-                                           doLogCollect=True)
+                                           doLogCollect=True,
+                                           maxpss=self.harvestingMemory)
 
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
@@ -488,7 +489,6 @@ class ExpressWorkloadFactory(StdBase):
                     "MaxInputSize": {"type": int, "optional": False},
                     "MaxInputFiles": {"type": int, "optional": False},
                     "MaxLatency": {"type": int, "optional": False},
-
                     }
         baseArgs.update(specArgs)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/Express_t.py
@@ -52,7 +52,8 @@ REQUEST = {
     "ScramArch": "slc6_amd64_gcc530",
     "Scenario": "test_scenario",
     "SpecialDataset": "StreamExpress",
-    "StreamName": "Express"
+    "StreamName": "Express",
+    "HarvestingMemory": 3000.0
 }
 
 


### PR DESCRIPTION
Fixes #11364

#### Status
READY

#### Description
Two things are happening here.
* The `StdBase` module creates the new attribute `StdBase.harvestingTaskMemory`, with default value of `2300 MB`
* The addDQMHarvestingTask now uses the new `harvestingTaskMemory` attribute to set a custom value if desired

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
T0 PR: https://github.com/dmwm/T0/pull/5102

#### External dependencies / deployment changes
No.
