### PR TITLE
Add SQL schema wmcoredb package as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ rucio-clients~=36.5.0         # wmcore,wmagent,wmglobalqueue,msunmerged,msoutput
 Sphinx~=5.1.1                 # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue
 SQLAlchemy~=1.4.40            # wmcore,wmagent
 PyJWT~=2.4.0                  # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
+wmcoredb>=0.8.7               # wmcore,wmagent,wmagentdev


### PR DESCRIPTION
Partially fixes #12339 

#### Status
ready

#### Description
This pull request adds a new dependency to wmcore/wmagent, the `wmcoredb` data-only package with the SQL database schema. Now available under: https://pypi.org/project/wmcoredb/

Note that this is one of the requirements for this PR: https://github.com/dmwm/WMCore/pull/12341, which I prefer to first have the package such that we can correct the SQL file path if needed. Once this one is merged, I will rebase/update the already in progress PR https://github.com/dmwm/WMCore/pull/12341

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
A dependency for: https://github.com/dmwm/WMCore/pull/12341

#### External dependencies / deployment changes
None