### PR TITLE
Skip PyPi publication if same package+version has already been uploaded

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -35,11 +35,13 @@ jobs:
                  msoutput, mspileup, msrulecleaner, mstransferor, msmonitor]
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup python 3.8
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: '3.12'
 
       # setup ubuntu Linux with packages required for installing locally WM
       # python packages, e.g. we need curl-config for pycurl (it comes from dev

--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -98,6 +98,8 @@ jobs:
       # perform CI/CD actions to upload WM packages to PyPi
       - name: Upload package distribution to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   # second job, depends on build_and_publish_services, builds and upload
   # docker images to CERN registry


### PR DESCRIPTION
No issue created for this

#### Status
ready

#### Description
Configure PyPi publication action to not fail if a package and version has already been uploaded to PyPi repository.

This will make retrigger of failed CD pipelines more functional (or actually functional).

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
Trying to resolve a CD action that failed to resolve `rucio-clients` in 2.4.2rc1, see: https://github.com/dmwm/WMCore/actions/runs/16171960825/job/45647527244#step:10:36