### PR TITLE
Install setuptools in the CD pipeline

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -53,9 +53,10 @@ jobs:
           sudo apt install -y curl libcurl4-openssl-dev
 
       # upgrade pip
-      - name: Upgrade pip3
+      - name: Upgrade pip3 and install build tools
         run: |
           python3 -m pip install --upgrade pip
+          python3 -m pip install setuptools wheel
 
       # create appropriate setup.py for python builds
       - name: Update the setup script template with package name
@@ -75,8 +76,6 @@ jobs:
       # this step will build tarball and whl files for our matrix.target WM package
       - name: Build sdist and bdist_wheel
         run: |
-          echo "install wheel package from pip to build wheels"
-          pip install wheel
           echo "build WMCore sdist and wheels"
           python3 setup.py clean sdist bdist_wheel
 


### PR DESCRIPTION
No issue created
Follow up of https://github.com/dmwm/WMCore/pull/12410

#### Status
not-tested

#### Description
And now that we adopted Python 3.12 in the CD pipeline, the build for 2.4.2rc2 failed because it could not find `setuptools`, see: https://github.com/dmwm/WMCore/actions/runs/16173687513/job/45653402846#step:8:26

With this, we explicitly install setuptools package.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
