### PR TITLE
update CMSMonitoring version to upgrade jsonschema dependency to align with rucio-clients

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 CT3~=3.4.0                    # wmcore,wmagent,reqmgr2,reqmon
 CherryPy~=18.8.0              # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 CMSCouchapp~=1.3.4            # wmcore,wmagent
-CMSMonitoring~=0.6.10         # wmcore,wmagent,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
+CMSMonitoring~=0.6.13         # wmcore,wmagent,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 coverage~=5.4                 # wmcore,wmagent,wmagentdev
 cx-Oracle~=8.3.0              # wmcore,wmagent
 dbs3-client==4.0.19           # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msoutput,mstransferor


### PR DESCRIPTION
Fixes #12032 

#### Status
ready

#### Description
Upgrade `CMSMonitoring` version which by itself upgraded `jsonschema` package version to align with `rucio-clients` requirements on `jsonschema` package. This is an example of Python dependency failure among independent python packages which rely on common python package but using different version in their `requirements.txt` file. The new tag of `CMSMonitoring` upgrades `jsonschema` to version `>=4.20.0` required by `rucio-clients` package.

#### Is it backward compatible (if not, which system it affects?)
MAYBE

Please note: I performed only basic test with CMSMonitoring by loading `jsonschema` package and validating test schema with it. The inter package compatibility, like CMSMonitoring and WM packages were not checked.

#### Related PRs
- https://github.com/dmwm/WMCore/pull/12411
- https://github.com/dmwm/WMCore/pull/12410
- https://github.com/dmwm/WMCore/pull/12201

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
