### PR TITLE
Added mongomock to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ Jinja2~=3.1.2                 # wmcore,wmagent
 memory-profiler~=0.60.0       # wmcore,wmagentdev
 mock~=4.0.3                   # wmcore,wmagent,wmagentdev
 mox3~=1.1.0                   # wmcore,wmagentdev
+mongomock~=4.3.0              # wmcore,wmagentdev
 mysqlclient~=2.1.1            # wmcore,wmagent
 pynose~=1.5.4                 # wmcore,wmagentdev
 pycodestyle~=2.8.0            # wmcore,wmagentdev


### PR DESCRIPTION
Fixes #10978 

#### Status
ready

#### Description
Add mongomock to the dependencies for wmcore and wmagentdev since we now use pypi instead of RPMs.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#11007
https://github.com/cms-sw/cmsdist/pull/7598

#### External dependencies / deployment changes
Yes, adds mongomock for unittests
