### PR TITLE
Add support to JobExtraMatchRequirements task parameter

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -436,6 +436,9 @@ class StdBase(object):
         else:
             gpuParams = json.loads(self.gPUParams)
         procTaskCmsswHelper.setGPUSettings(gpuRequired, gpuParams)
+        # Parameter used only for job classad (job matchmaking)
+        extraRequirements = self.jobExtraMatchRequirements
+        procTask.setJobExtraMatchRequirements(taskConf.get('JobExtraMatchRequirements', extraRequirements))
 
         procTaskCmsswHelper.setUserSandbox(userSandbox)
         procTaskCmsswHelper.setUserFiles(userFiles)
@@ -1084,7 +1087,8 @@ class StdBase(object):
                      "RequiresGPU": {"default": "forbidden",
                                      "validate": lambda x: x in ("forbidden", "optional", "required")},
                      "GPUParams": {"default": json.dumps(None), "validate": gpuParameters},
-
+                     "JobExtraMatchRequirements": {"default": "", "type": str,
+                                                   "validate": lambda x: len(x) < 10000},
 
                      # FIXME (Alan on 27/Mar/017): maybe used by T0 during creation???
                      "MinMergeSize": {"default": 2 * 1024 * 1024 * 1024, "type": int,

--- a/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/TaskChain.py
@@ -657,6 +657,8 @@ class TaskChainWorkloadFactory(StdBase):
             "SizePerEvent": {"type": float, "optional": True, "validate": lambda x: x > 0},
             'PrimaryDataset': {'default': None, 'optional': not generator, 'validate': primdataset,
                                'null': False},
+            "JobExtraMatchRequirements": {"default": "", "type": str,
+                                          "validate": lambda x: len(x) < 10000},
                     }
         baseArgs.update(arguments)
         StdBase.setDefaultArgumentsProperty(baseArgs)

--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -1581,6 +1581,23 @@ class WMTaskHelper(TreeHelper):
                 return stepHelper.getGPURequirements()
         return gpuRequirements
 
+    def setJobExtraMatchRequirements(self, extraRequirements):
+        """
+        Set the job extra matchmaking requirements for this task
+        :param extraRequirements: string with the extra match requirements
+        :return: nothing, the workload spec is updated in place.
+        """
+        self.data.constraints.jobExtraMatchRequirements = extraRequirements
+        #for task in self.childTaskIterator():
+        #    task.setJobExtraMatchRequirements(extraRequirements)
+
+    def getJobExtraMatchRequirements(self):
+        """
+        Get the job extra matchmaking requirements for this task
+        :return: string with the extra match requirements
+        """
+        return getattr(self.data.constraints, 'jobExtraMatchRequirements', "")
+
     def _getStepValue(self, keyDict, defaultValue):
         """
         __getStepValue_

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/ReReco_t.py
@@ -4,13 +4,10 @@ _ReReco_t_
 
 Unit tests for the ReReco workflow.
 """
-from __future__ import print_function
-from future.utils import viewitems
-
 import os
 import threading
 import unittest
-
+import json
 from Utils.PythonVersion import PY3
 
 from WMCore.DAOFactory import DAOFactory
@@ -162,7 +159,7 @@ class ReRecoTest(unittest.TestCase):
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"RECOoutput": "RECO", "DQMoutput": "DQM"}
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             mergedOutput = procWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = procWorkflow.outputMap[fset][0]["output_fileset"]
@@ -186,7 +183,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/DataProcessingMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
@@ -258,7 +255,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                          "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/unmerged-%s" % fset)
             unmerged.loadData()
@@ -320,7 +317,7 @@ class ReRecoTest(unittest.TestCase):
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"SkimA": "RAW-RECO", "SkimB": "USER"}
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             mergedOutput = skimWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = skimWorkflow.outputMap[fset][0]["output_fileset"]
@@ -348,7 +345,7 @@ class ReRecoTest(unittest.TestCase):
                          "/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/SomeSkimMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
@@ -394,7 +391,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(skimSubscription["split_algo"], "FileBased",
                          "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             unmerged = Fileset(
                 name="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-%s" % fset)
@@ -410,7 +407,7 @@ class ReRecoTest(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                              "Error: Wrong split algo.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             unmerged = Fileset(
                 name="/TestWorkload/DataProcessing/DataProcessingMergeRECOoutput/SomeSkim/unmerged-%s" % fset)
@@ -528,7 +525,7 @@ class ReRecoTest(unittest.TestCase):
                          "Error: Wrong number of WF outputs.")
 
         goldenOutputMods = {"SkimA": "RAW-RECO", "SkimB": "USER"}
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             fset = goldenOutputMod + tier
             mergedOutput = skimWorkflow.outputMap[fset][0]["merged_output_fileset"]
             unmergedOutput = skimWorkflow.outputMap[fset][0]["output_fileset"]
@@ -553,7 +550,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(unmergedLogArchOutput.name, "/TestWorkload/DataProcessing/SomeSkim/unmerged-logArchive",
                          "Error: LogArchive output fileset is wrong.")
 
-        for goldenOutputMod, tier in viewitems(goldenOutputMods):
+        for goldenOutputMod, tier in goldenOutputMods.items():
             mergeWorkflow = Workflow(name="TestWorkload",
                                      task="/TestWorkload/DataProcessing/SomeSkim/SomeSkimMerge%s" % goldenOutputMod)
             mergeWorkflow.load()
@@ -599,7 +596,7 @@ class ReRecoTest(unittest.TestCase):
         self.assertEqual(skimSubscription["split_algo"], "FileBased",
                          "Error: Wrong split algo.")
 
-        for skimOutput, tier in viewitems(goldenOutputMods):
+        for skimOutput, tier in goldenOutputMods.items():
             fset = skimOutput + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/SomeSkim/unmerged-%s" % fset)
             unmerged.loadData()
@@ -614,7 +611,7 @@ class ReRecoTest(unittest.TestCase):
             self.assertEqual(mergeSubscription["split_algo"], "ParentlessMergeBySize",
                              "Error: Wrong split algo.")
 
-        for skimOutput, tier in viewitems(goldenOutputMods):
+        for skimOutput, tier in goldenOutputMods.items():
             fset = skimOutput + tier
             unmerged = Fileset(name="/TestWorkload/DataProcessing/SomeSkim/unmerged-%s" % fset)
             unmerged.loadData()
@@ -883,7 +880,6 @@ class ReRecoTest(unittest.TestCase):
         subscriptions = self.listSubsMapping.execute(workflow="TestWorkload", returnTuple=True)
         self.assertItemsEqual(subscriptions, subMaps)
 
-
     def testCampaignName(self):
         """
         Make sure the campaign name has been set in the processing task
@@ -913,7 +909,49 @@ class ReRecoTest(unittest.TestCase):
             taskObj = testWorkload.getTaskByPath(task)
             self.assertEqual(taskObj.getCampaignName(), '')
 
-        return
+    def testReRecoGPU(self):
+        """
+        _testReRecoGPU_
+
+        Verify that ReReco workflows can be created and inserted into WMBS
+        correctly.
+        """
+        skimConfig = self.injectSkimConfig()
+        recoConfig = self.injectReRecoConfig()
+        dataProcArguments = ReRecoWorkloadFactory.getTestArguments()
+        dataProcArguments["ProcessingString"] = "ProcString"
+        dataProcArguments["ConfigCacheID"] = recoConfig
+        dataProcArguments.update({"SkimName1": "SomeSkim",
+                                  "SkimInput1": "RECOoutput",
+                                  "Skim1ConfigCacheID": skimConfig})
+        dataProcArguments["CouchURL"] = os.environ["COUCHURL"]
+        dataProcArguments["CouchDBName"] = "rereco_t"
+        dataProcArguments["EnableHarvesting"] = True
+        dataProcArguments["DQMConfigCacheID"] = self.injectDQMHarvestConfig()
+
+        # GPU settings
+        dataProcArguments["RequiresGPU"] = "required"
+        gpuParams = {"GPUMemoryMB": 12345, "CUDARuntime": "12.2", "CUDACapabilities": ["11.2", "12.2"]}
+        dataProcArguments["GPUParams"] = json.dumps(gpuParams)
+        extraReqs = 'regexp("^NVIDIA L40S$", GPUs_DeviceName)'
+        dataProcArguments["JobExtraMatchRequirements"] = extraReqs
+
+        print(f"Creating workload with arguments: {dataProcArguments}")
+        factory = ReRecoWorkloadFactory()
+        testWorkload = factory.factoryWorkloadConstruction("TestWorkload", dataProcArguments)
+
+        for task in testWorkload.getAllTasks():
+            print(f"Task name: {task.name()}")
+            print(f"Task type: {task.taskType()}")
+            print(f"Task requires GPU: {task.getRequiresGPU()}")
+            print(f"Task job extra match requirements: {task.getJobExtraMatchRequirements()}")
+            if task.taskType() in ["Processing", "Skim"]:
+                self.assertEqual(task.getRequiresGPU(), "required")
+                self.assertEqual(task.getJobExtraMatchRequirements(), extraReqs)
+            else:
+                self.assertEqual(task.getRequiresGPU(), "forbidden")
+                self.assertEqual(task.getJobExtraMatchRequirements(), "")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
+++ b/test/python/WMCore_t/WMSpec_t/StdSpecs_t/StepChain_t.py
@@ -2436,9 +2436,10 @@ class StepChainTests(EmulatedUnitTestCase):
         testWorkload = factory.factoryWorkloadConstruction("TestWorkload", testArguments)
         self.assertIsNone(testArguments['RequiresGPU'])
         self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        self.assertEqual(testArguments['JobExtraMatchRequirements'], "")
         for stepKey in ['Step1', 'Step2', 'Step3']:
-            self.assertTrue("RequiresGPU" not in testArguments[stepKey])
-            self.assertTrue("GPUParams" not in testArguments[stepKey])
+            for paramKey in ("RequiresGPU", "GPUParams", "JobExtraMatchRequirements"):
+                self.assertTrue(paramKey not in testArguments[stepKey])
 
         for taskName in testWorkload.listAllTaskNames():
             taskObj = testWorkload.getTaskByName(taskName)
@@ -2457,9 +2458,10 @@ class StepChainTests(EmulatedUnitTestCase):
 
         self.assertIsNone(testArguments['RequiresGPU'])
         self.assertEqual(testArguments['GPUParams'], json.dumps(None))
+        self.assertEqual(testArguments['JobExtraMatchRequirements'], "")
         for stepKey in ['Step1', 'Step2', 'Step3']:
-            self.assertTrue("RequiresGPU" not in testArguments[stepKey])
-            self.assertTrue("GPUParams" not in testArguments[stepKey])
+            for paramKey in ("RequiresGPU", "GPUParams", "JobExtraMatchRequirements"):
+                self.assertTrue(paramKey not in testArguments[stepKey])
 
         for taskName in testWorkload.listAllTaskNames():
             taskObj = testWorkload.getTaskByName(taskName)
@@ -2470,6 +2472,15 @@ class StepChainTests(EmulatedUnitTestCase):
                     self.assertIsNone(stepHelper.data.application.gpu.gpuRequirements)
                 else:
                     self.assertFalse(hasattr(stepHelper.data.application, "gpu"))
+
+
+        # now test a failing case for the extra GPU parameters
+        for wrongValues in (None, {"test"}, 123, 123.4, ["wrong"], 20000 * "a"):
+            testArguments['JobExtraMatchRequirements'] = wrongValues
+            with self.assertRaises(WMSpecFactoryException):
+                factory.factoryWorkloadConstruction("PullingTheChain", testArguments)
+        # roll it back to a valid value
+        testArguments['JobExtraMatchRequirements'] = ""
 
         # last but not least, test a failing case
         testArguments['RequiresGPU'] = "required"


### PR DESCRIPTION
Fixes #12406 

#### Status
ready

#### Description
Provide a new workflow parameter (workload/task-level) named `JobExtraMatchRequirements`, with the goal to allow users to provide a string (up to 10k chars) to be defined as job classad for job/resource matchmaking. 

Note that this change is only affecting the request layer, whereas job-level development is to be implemented in a future PR.

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
WMAgent development still to be implemented.

#### External dependencies / deployment changes
Documentation updated: https://gitlab.cern.ch/dmwm/wmcore-docs/-/blob/master/docs/wmcore/GPU-Support.md
