### PR TITLE
Fix WMCore.Database package dependency for reqmon system

### DIFF
--- a/setup_dependencies.py
+++ b/setup_dependencies.py
@@ -239,9 +239,8 @@ dependencies = {
         'packages': ['WMCore.WMStats+', 'WMCore.Services+', 'WMCore.Wrappers+',
                      'WMCore.ReqMgr.DataStructs+'
                      ],
-        'modules': ['WMCore.Database.__init__', 'WMCore.Database.CMSCouch',
-                    'WMCore.Database.CouchUtils', 'WMCore.ReqMgr.__init__'],
-        'systems': ['wmcbase', 'wmcrest'],
+        'modules': ['WMCore.ReqMgr.__init__'],
+        'systems': ['wmcbase', 'wmcrest', 'wmcdatabase'],
         'statics': ['src/couchapps/WMStats+',
                     'src/couchapps/WMStatsErl+',
                     'src/couchapps/WMStatsErl1+',


### PR DESCRIPTION
Fixes #11918 
Complement to https://github.com/dmwm/WMCore/pull/12353

#### Status
not-tested

#### Description
This is meant to fix the following issue for `reqmon` and `t0reqmon` systems:
```
ModuleNotFoundError: No module named 'WMCore.Database.CouchMonitoring'
```

Instead of justing adding this python package, I decided to add the full `wmcdatabase` meta-package - similarly to what is done for `reqmgr2`.

This is tricky to test, so I will go ahead and test it once the CD pipeline builds a new tag.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fix issue inserted with https://github.com/dmwm/WMCore/pull/12353 (present in 2.4.2rc8 and 2.4.2rc9)

#### External dependencies / deployment changes
None