### PR TITLE
Workaround to avoid dependency conflicts (requests package)  at WN le…

### DIFF
--- a/src/python/WMCore/Database/CMSCouch.py
+++ b/src/python/WMCore/Database/CMSCouch.py
@@ -32,7 +32,6 @@ from http.client import HTTPException
 from Utils.IteratorTools import grouper, nestedDictUpdate
 from WMCore.Lexicon import sanitizeURL
 from WMCore.Services.Requests import JSONRequests
-from WMCore.Database.CouchMonitoring import checkStatus
 
 
 def check_name(dbname):
@@ -1283,6 +1282,10 @@ class CouchMonitor(object):
         :return: a list of dictionaries with the status of the replications and an
             error message
         """
+        # Do not import checkStatus at the beginning of the CMSCouch module
+        # to avoid dependecy conflicts in the CMS Sandbox at the WN level
+        from WMCore.Database.CouchMonitoring import checkStatus
+
         output = []
         sdict = checkStatus(kind='scheduler')
         rdict = checkStatus(kind='replicator')


### PR DESCRIPTION
Workaround to avoid dependency conflicts (requests package)  at WN level while loading error types in WMConfigCache

Fixes #11918 
Complements #12425 and #12353

#### Status
ready

#### Description
Do not import checkStatus at the beginning of the file.
Workaround for the following failure at the worker node level:

```
INFO:root:Creating WM runtime information json took 0.196 seconds to complete
Traceback (most recent call last):
  File "Startup.py", line 42, in <module>
    Bootstrap.createWMRuntimeJson(outputPath=os.getcwd())
  File "/srv/job/WMCore.zip/WMCore/WMRuntime/Bootstrap.py", line 250, in createWMRuntimeJson
  File "/srv/job/WMCore.zip/WMCore/WMSpec/WMTask.py", line 1283, in getScramArch
  File "/srv/job/WMCore.zip/WMCore/WMSpec/WMTask.py", line 281, in getStepHelper
  File "/srv/job/WMCore.zip/WMCore/WMSpec/Steps/StepFactory.py", line 107, in getStepTemplate
  File "/srv/job/WMCore.zip/WMCore/WMFactory.py", line 58, in loadObject
  File "<frozen zipimport>", line 259, in load_module
  File "/srv/job/WMCore.zip/WMCore/WMSpec/Steps/Templates/CMSSW.py", line 16, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/srv/job/WMCore.zip/WMCore/Cache/WMConfigCache.py", line 25, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/srv/job/WMCore.zip/WMCore/Database/CMSCouch.py", line 35, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/srv/job/WMCore.zip/WMCore/Database/CouchMonitoring.py", line 41, in <module>
ModuleNotFoundError: No module named 'requests'
Traceback (most recent call last):
  File "/srv/job/Utils/Timestamps.py", line 86, in <module>
    main()
  File "/srv/job/Utils/Timestamps.py", line 66, in main
    with open(reportFile, 'rb') as istream:
FileNotFoundError: [Errno 2] No such file or directory: 'WMTaskSpace/Report.0.pkl'
+ cp WMTaskSpace/Report.0.pkl ../
cp: cannot stat 'WMTaskSpace/Report.0.pkl': No such file or directory
+ ls -l WMTaskSpace
ls: cannot access WMTaskSpace: No such file or directory
+ ls -l 'WMTaskSpace/*'
ls: cannot access WMTaskSpace/*: No such file or directory
+ set +x
```

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Complements #12425 and #12353

More details here:
https://mattermost.web.cern.ch/cms-o-and-c/pl/akf6eua5o7y59mm5dcqa7s37oo
