### PR TITLE
debug: add additional log statements to DBS3Reader

### DIFF
--- a/src/python/WMCore/Services/DBS/DBS3Reader.py
+++ b/src/python/WMCore/Services/DBS/DBS3Reader.py
@@ -88,13 +88,19 @@ class DBS3Reader(object):
 
         # instantiate dbs api object
         try:
-            self.dbsURL = url.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
-            self.dbs = DbsApi(self.dbsURL, **contact)
             self.logger = logger or logging.getLogger(self.__class__.__name__)
+            self.dbsURL = url.replace("cmsweb.cern.ch", "cmsweb-prod.cern.ch")
+            # check if self does not have attribute dbsURL
+            self.logger.info(f"input url: {url}")
+            if not hasattr(self, "dbsURL"):
+                self.logger.info(f"DBS3Reader does NOT have attribute dbsURL")
+            self.dbs = DbsApi(self.dbsURL, **contact)
             self.parallel = parallel
         except Exception as ex:
             msg = "Error in DBSReader with DbsApi\n"
             msg += "%s\n" % formatEx3(ex)
+            import traceback
+            print(traceback.format_exc())
             raise DBSReaderError(msg) from None
 
     def _getLumiList(self, blockName=None, lfns=None, validFileOnly=1):


### PR DESCRIPTION
Tests cmsweb url on WorkQueueManager, Related to issue #12429

#### Status
**Do  Not Merge**

#### Description
Additional Log statements to test crashing WorkQueueManage

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
#12431

#### External dependencies / deployment changes
NO
