### PR TITLE
Make NanoAOD input data chunk policy consistent for RelVal workflows

### DIFF
--- a/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
+++ b/src/python/WMCore/MicroService/MSTransferor/RequestInfo.py
@@ -139,14 +139,14 @@ class RequestInfo(MSCore):
         """
         workflows = []
         for record in reqRecords:
-            if record.get("SubRequestType") in ['RelVal', 'HIRelVal']:
+            if isNanoWorkflow(record):
+                wflow = NanoWorkflow(record['RequestName'], record, logger=self.logger)
+            elif record.get("SubRequestType") in ['RelVal', 'HIRelVal']:
                 wflow = RelValWorkflow(record['RequestName'], record, logger=self.logger)
             elif record.get("RequestType") == "DQMHarvest":
                 wflow = DQMHarvestWorkflow(record['RequestName'], record, logger=self.logger)
             elif record.get("OpenRunningTimeout", 0) > self.openRunning:
                 wflow = GrowingWorkflow(record['RequestName'], record, logger=self.logger)
-            elif isNanoWorkflow(record):
-                wflow = NanoWorkflow(record['RequestName'], record, logger=self.logger)
             else:
                 wflow = Workflow(record['RequestName'], record, logger=self.logger)
 

--- a/test/data/ReqMgr/requests/Integration/SC_Nano.json
+++ b/test/data/ReqMgr/requests/Integration/SC_Nano.json
@@ -29,7 +29,7 @@
             "CheckList": "StepChain with Dataset start policy; EventAwareLumiBased splitting hardcoded to 10k EpJ (10 lumis)",
             "WorkFlowDesc": [
                 "SC processing a MINIAODSIM, thus locking all of the input blocks at the same location (with copies=2);",
-                "Request 4GB and 2 cores; Job splitting hardcoded to 10k EpJ (input data with 1k EpL"
+                "Request 4GB and 2 cores; Job splitting hardcoded to 10k EpJ (input data with 1k EpL. Single WQE with full container."
             ]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
@@ -53,7 +53,7 @@
             "slc7_amd64_gcc700"
         ],
         "SizePerEvent": 33.1848,
-        "SubRequestType": "ReDigi",
+        "SubRequestType": "RelVal",
         "Step1": {
             "AcquisitionEra": "RunIISummer20UL17NanoAODv9",
             "CMSSWVersion": "CMSSW_10_6_26",


### PR DESCRIPTION
Fixes #12421 

#### Status
not-tested

#### Description
With this change, we consider full container data placement for Release Validation workflows as well - making it consistent with the `Dataset` WorkQueue policy defined at the WMSpec factory.

#### Is it backward compatible (if not, which system it affects?)
YES (won't fix workflows already placed at block-level though)

#### Related PRs
None

#### External dependencies / deployment changes
None