### PR TITLE
Parsing releases.map from cvmfs into xml file

### DIFF
--- a/src/python/WMCore/Services/TagCollector/TagCollector.py
+++ b/src/python/WMCore/Services/TagCollector/TagCollector.py
@@ -6,6 +6,7 @@ from Utils.Utilities import decodeBytesToUnicode
 standard_library.install_aliases()
 
 import logging
+
 from urllib.parse import urlparse
 
 from collections import defaultdict
@@ -39,6 +40,72 @@ class TagCollector(Service):
         super(TagCollector, self).__init__(configDict)
         self['logger'].debug("Initializing TagCollector with url: %s", self['endpoint'])
 
+        self.cvmfsReleasesMap = "/cvmfs/cms.cern.ch/releases.map"
+        self.tmpReleasesXML = "/tmp/ReleasesXML"
+
+    def parseCvmfsReleasesXML(self, releasesMap, releasesXML):
+        """
+        Parses the ReleasesXML file from the releases.map in cvmfs
+        """
+        production = "type=Production;"
+        announced="state=Announced;"
+        anyarch=False
+        architecture=""
+        archs = {}
+        rels = []
+
+        with open(releasesMap, "r", encoding="utf-8") as releasesFile:
+            for line in releasesFile:
+                if not anyarch and 'prodarch=1;' not in line:
+                    continue
+
+                if production and production not in line:
+                    continue
+
+                if announced and announced not in line:
+                    continue
+
+                if architecture and architecture not in line:
+                    continue
+
+                data = {}
+                for item in line.split(";"):
+                    if "=" not in item:
+                        continue
+                    k, v = item.split("=")
+                    data[k] = v
+
+                if "architecture" in data and "label" in data and "type" in data and "state" in data:
+                    if not anyarch and data["label"] in rels:
+                        continue
+
+                    rels.append(data["label"])
+                    arch = data["architecture"]
+
+                    if arch not in archs:
+                        archs[arch] = []
+
+                    extraTag = ""
+                    if "default_micro_arch" in data:
+                        extraTag = ' default_micro_arch="%s"' % data["default_micro_arch"]
+
+                    data["extra_tag"] = extraTag
+                    archs[arch].append(
+                        """<project label="%(label)s" type="%(type)s" state="%(state)s"%(extra_tag)s/>"""
+                        % data
+                    )
+
+        with open(releasesXML, "w", encoding="utf-8") as xml:
+            xml.write("<projects>\n")
+            for arch in archs:
+                xml.write('  <architecture name="%s">\n' % arch)
+                for rel in archs[arch]:
+                    xml.write("    %s\n" % rel)
+                xml.write("  </architecture>\n")
+            xml.write("</projects>\n")
+
+        return
+
     def _getResult(self, callname="", clearCache=False,
                    args=None, verb="GET", encoder=None, decoder=None,
                    contentType=None):
@@ -50,23 +117,38 @@ class TagCollector(Service):
 
         TODO: Probably want to move this up into Service
         """
-        if not args:
-            args = self.tcArgs
+        try:
+            if not args:
+                args = self.tcArgs
 
-        cFile = '%s_%s'% (self.cFileUrlPath, callname.replace("/", "_"))
-        # If no callname or url path, the base host is getting queried
-        if cFile == '_':
-            cFile = 'baseRequest'
+            cFile = '%s_%s'% (self.cFileUrlPath, callname.replace("/", "_"))
+            # If no callname or url path, the base host is getting queried
+            if cFile == '_':
+                cFile = 'baseRequest'
 
-        if clearCache:
-            self.clearCache(cFile, args, verb)
+            if clearCache:
+                self.clearCache(cFile, args, verb)
 
-        # Note cFile is just the base name pattern, args 
-        # are also considered for the end filename in the method below
-        f = self.refreshCache(cFile, callname, args, encoder=encoder, decoder=decodeBytesToUnicode,
-                              verb=verb, contentType=contentType)
-        result = f.read()
-        f.close()
+            # Note cFile is just the base name pattern, args 
+            # are also considered for the end filename in the method below
+            f = self.refreshCache(cFile, callname, args, encoder=encoder, decoder=decodeBytesToUnicode,
+                                verb=verb, contentType=contentType)
+            result = f.read()
+            f.close()
+        except:
+            logging.error('Something went wrong accessing ReleasesXML from cmssdt, perhaps the service is temporarily down')
+            logging.info('Retrying to access ReleasesXML from cvmfs')
+        
+            try:
+                self.parseCvmfsReleasesXML(releasesMap=self.cvmfsReleasesMap, releasesXML=self.tmpReleasesXML)
+                with open('/tmp/ReleasesXML', 'r', encoding='utf-8') as f:
+                    result = f.read()
+                f.close()
+            except:
+                logging.error('Something went wrong parsing /cvmfs/cms.cern.ch/releases.map into XML format, perhaps cvmfs is not mounted')
+                logging.exception('Unable to access ReleasesXML from cmssdt and cvmfs')
+                raise
+
 
         # overhead from REST model which returns results as strings or None
         # therefore they can be encoded by JSON to None, etc.

--- a/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
+++ b/test/python/WMCore_t/Services_t/TagCollector_t/TagCollector_t.py
@@ -5,8 +5,11 @@ Created on Dec 16, 2016
 from __future__ import (division, print_function)
 
 import unittest
+import logging
 
+from collections import defaultdict
 from WMCore.Services.TagCollector.TagCollector import TagCollector
+from WMCore.Services.TagCollector.XMLUtils import xml_parser
 
 
 class TagCollectorTest(unittest.TestCase):
@@ -17,12 +20,87 @@ class TagCollectorTest(unittest.TestCase):
         """
         # using the default production server
         self.tagCollecor = TagCollector()
+        self.testReleasesMap = "/tmp/testReleasesParsing.map"
+        self.testReleasesXML = "/tmp/testReleasesParsingXML"
+
         return
 
+    def _getResult(self, testReleasesMap=None, testReleasesXML=None):
+        """
+        _getResult_
+
+        Test the XML formatted information parsed by parseCvmfsReleasesXML
+        """
+        try:
+            self.tagCollecor.parseCvmfsReleasesXML(releasesMap=testReleasesMap, releasesXML=testReleasesXML)
+            with open(testReleasesXML, 'r', encoding='utf-8') as f:
+                result = f.read()
+            f.close()
+        except Exception:
+            logging.error('Something went wrong parsing the test releasesMap into the sample XML file')
+            raise
+
+        return result
+    
+    def data(self, testReleasesMap=None, testReleasesXML=None):
+        """
+        _data_
+
+        Test: Fetch data from cvmfs releases.map
+        """
+
+        data = self._getResult(testReleasesMap=testReleasesMap, testReleasesXML=testReleasesXML)
+        pkey = 'architecture'
+        for row in xml_parser(data, pkey):
+            yield row[pkey]
+
+    def releases(self, arch=None, testReleasesMap=None, testReleasesXML=None):
+        """
+        _releases_
+
+        Test: Yield CMS releases known in tag collector from cvmfs releases.map
+        """
+        arr = []
+        for row in self.data(testReleasesMap=testReleasesMap, testReleasesXML=testReleasesXML):
+            if arch:
+                if arch == row['name']:
+                    for item in row['project']:
+                        arr.append(item['label'])
+            else:
+                for item in row['project']:
+                    arr.append(item['label'])
+        return list(set(arr))
+
+    def architectures(self, arch=None, testReleasesMap=None, testReleasesXML=None):
+        """
+        _architectures_
+
+        Test: Yield CMS architectures known in tag collector from cvfms releases.map
+        """
+        arr = []
+        for row in self.data(testReleasesMap=testReleasesMap, testReleasesXML=testReleasesXML):
+            arr.append(row['name'])
+        return list(set(arr))
+    
+    def releases_by_architecture(self, testReleasesMap=None, testReleasesXML=None):
+        """
+        _releases_by_architecture_
+
+        Test: returns CMS architectures and realease in dictionary format with cvmfs as main source
+        """
+        arch_dict = defaultdict(list)
+        for row in self.data(testReleasesMap=testReleasesMap, testReleasesXML=testReleasesXML):
+            releases = set()
+            for item in row['project']:
+                releases.add(item['label'])
+            arch_dict[row['name']].extend(list(releases))
+        return dict(arch_dict)
+    
     def testTagCollecorMethods(self):
         """
         _testTagCollecorMethods_
         """
+
         releases = self.tagCollecor.releases()
         architectures = self.tagCollecor.architectures()
         realsese_by_arch = self.tagCollecor.releases_by_architecture()
@@ -42,8 +120,30 @@ class TagCollectorTest(unittest.TestCase):
         self.assertEqual(3, microarch_testCMSSW_15)
         self.assertEqual(0, microarch_testCMSSW_7_12)
 
-        return
+        releasesMap = (
+                        "architecture=el8_amd64_gcc12;label=CMSSW_15_0_15_patch3;type=Production;state=Announced;prodarch=1;default_micro_arch=x86-64-v3;\n"
+                        "architecture=el8_amd64_gcc12;label=CMSSW_15_0_15_patch4;type=Production;state=Announced;prodarch=1;default_micro_arch=x86-64-v3;\n"
+                        "architecture=el8_amd64_gcc13;label=CMSSW_16_0_0_pre1_FASTPU;type=Development;state=Announced;prodarch=1;default_micro_arch=x86-64-v3;\n"
+                        "architecture=el9_amd64_gcc12;label=CMSSW_15_0_15_patch3;type=Production;state=Announced;prodarch=1;default_micro_arch=x86-64-v3;\n"
+                        "architecture=el9_amd64_gcc12;label=CMSSW_15_0_15_patch4;type=Production;state=Announced;prodarch=1;default_micro_arch=x86-64-v3;\n"
+                    )
+        
+        with open(self.testReleasesMap, "w", encoding="utf-8") as f:
+            f.write(releasesMap)
 
+        releasesCvmfs = self.releases(testReleasesMap=self.testReleasesMap, testReleasesXML=self.testReleasesXML)
+        architecturesCvmfs = self.architectures(testReleasesMap=self.testReleasesMap, testReleasesXML=self.testReleasesXML)
+        realsese_by_arch_cvmfs = self.releases_by_architecture(testReleasesMap=self.testReleasesMap, testReleasesXML=self.testReleasesXML)
+
+        self.assertIn('CMSSW_15_0_15_patch3', releasesCvmfs)
+        self.assertIn('CMSSW_15_0_15_patch4', releasesCvmfs)
+        self.assertIn('el8_amd64_gcc12', architecturesCvmfs)
+        self.assertIn('el9_amd64_gcc12', architecturesCvmfs)
+        self.assertEqual(len(architecturesCvmfs), len(realsese_by_arch_cvmfs))
+        self.assertEqual(sorted(self.releases(arch='el8_amd64_gcc12', testReleasesMap=self.testReleasesMap, testReleasesXML=self.testReleasesXML)),
+                         sorted(realsese_by_arch_cvmfs.get('el8_amd64_gcc12')))
+
+        return
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #12419 

#### Status
Tested 

#### Description
Move away frome ReleasesXML in cmssdt. Use a new function to parse `/cvmfs/cms.cern.ch/releases.map` directlyt by the agent to XML format in `/tmp/ReleasesXML`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
