### PR TITLE
Unquote gpu related classads to be compatible with new requirements format

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -587,9 +587,9 @@ class SimpleCondorPlugin(BasePlugin):
                 # E.g.: ["1.0", "10.0", "2.1"]
                 cudaCapabilities = sorted(job['gpuRequirements']['CUDACapabilities'], key=float)
                 
-                ad['My.DESIRED_GPUMinimumCapability'] = classad.quote(str(cudaCapabilities[0]))
-                ad['My.DESIRED_GPUMaximumCapability'] = classad.quote(str(cudaCapabilities[-1]))
-                ad['My.DESIRED_GPURuntime'] = classad.quote(job['gpuRequirements']['CUDARuntime'])
+                ad['My.DESIRED_GPUMinimumCapability'] = str(cudaCapabilities[0])
+                ad['My.DESIRED_GPUMaximumCapability'] = str(cudaCapabilities[-1])
+                ad['My.DESIRED_GPURuntime'] = str(job['gpuRequirements']['CUDARuntime'])
             else:
                 ad['My.DESIRED_GPUMemoryMB'] = undefined
                 ad['My.DESIRED_GPUMinimumCapability'] = undefined


### PR DESCRIPTION
Fixes #12437

#### Status
tested

#### Description
Unquote gpu related classads to be compatible with new requirements format:

https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#gpus_minimum_capability

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12416

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?>
