### PR TITLE
Add support to user-provided match requirements at job creation/execution

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -145,6 +145,7 @@ def saveJob(job, thisJobNumber, **kwargs):
     job['allowOpportunistic'] = kwargs['allowOpportunistic']
     job['requiresGPU'] = kwargs['requiresGPU']
     job['gpuRequirements'] = kwargs['gpuRequirements']
+    job['jobExtraMatchRequirements'] = kwargs['jobExtraMatchRequirements']
     job['requestType'] = kwargs['requestType']
     job['physicsTaskType'] = kwargs['physicsTaskType']
     job['campaignName'] = kwargs['campaignName']
@@ -542,6 +543,7 @@ class JobCreatorPoller(BaseWorkerThread):
                                'numberOfCores': wmTask.getNumberOfCores(),
                                'requiresGPU': wmTask.getRequiresGPU(),
                                'gpuRequirements': wmTask.getGPURequirements(),
+                               'jobExtraMatchRequirements': wmTask.getJobExtraMatchRequirements(),
                                'inputDataset': wmTask.getInputDatasetPath(),
                                'inputPileup': wmTask.getInputPileupDatasets(),
                                'swVersion': wmTask.getSwVersion(allSteps=True),

--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -408,6 +408,7 @@ class JobSubmitterPoller(BaseWorkerThread):
                        'allowOpportunistic': loadedJob.get('allowOpportunistic', False),
                        'requiresGPU': loadedJob.get('requiresGPU', "forbidden"),
                        'gpuRequirements': loadedJob.get('gpuRequirements', None),
+                       'jobExtraMatchRequirements': loadedJob.get('jobExtraMatchRequirements', ""),
                        'campaignName': loadedJob.get('campaignName', None),
                        'requestType': loadedJob['requestType'],
                        'physicsTaskType': loadedJob.get('physicsTaskType', None)

--- a/src/python/WMCore/BossAir/RunJob.py
+++ b/src/python/WMCore/BossAir/RunJob.py
@@ -68,6 +68,7 @@ class RunJob(dict):
         self.setdefault('activity', None)
         self.setdefault('requiresGPU', 'forbidden')
         self.setdefault('gpuRequirements', None)
+        self.setdefault('jobExtraMatchRequirements', '')
         self.setdefault('campaignName', None)
         self.setdefault('requestType', None)
         self.setdefault('physicsTaskType', None)

--- a/test/data/ReqMgr/requests/Integration/SC_GPU.json
+++ b/test/data/ReqMgr/requests/Integration/SC_GPU.json
@@ -30,8 +30,8 @@
         "CMSSWVersion": "CMSSW_15_0_0_pre3",
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
-            "CheckList": "SC with required GPU in all 3 steps; 2 cores top level, but steps asking for 8; 8GB RAM",
-            "WorkFlowDesc": "SC with required GPU; 8 cores and 8GB RAM per step"
+            "CheckList": "SC with required GPU in all 3 steps and extra GPU match requirements; 2 cores top level, but steps asking for 8; 8GB RAM",
+            "WorkFlowDesc": "SC with required GPU and extra match-making; 8 cores and 8GB RAM per step"
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -44,6 +44,7 @@
         "GPUParams": "null",
         "GlobalTag": "142X_mcRun3_2025_realistic_v5",
         "IncludeParents": false,
+        "JobExtraMatchRequirements": "regexp(\"^NVIDIA L40S$\", GPUs_DeviceName)",
         "Memory": 8000,
         "Multicore": 2,
         "PrepID": "TEST-CMSSW_15_0_0_pre3__Run3_AMD_GPUValidation_SpecialRV_CNAF-TTbar_14TeV-00001",
@@ -71,7 +72,7 @@
             "Multicore": 8,
             "PrimaryDataset": "RelValTTbar_14TeV",
             "ProcessingString": "Step1_WMCore_TEST",
-            "RequestNumEvents": 9000,
+            "RequestNumEvents": 1000,
             "RequiresGPU": "required",
             "ScramArch": [
                 "el8_amd64_gcc12"

--- a/test/data/ReqMgr/requests/Integration/TC_GPU.json
+++ b/test/data/ReqMgr/requests/Integration/TC_GPU.json
@@ -30,8 +30,8 @@
         "CMSSWVersion": "CMSSW_15_0_0_pre3",
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
-            "CheckList": "",
-            "WorkFlowDesc": ""
+            "CheckList": "TC with required GPU in all 3 steps and extra matchmaking requirements; 1 cores and 3GB top level, but tasks use 8 cores/16GB",
+            "WorkFlowDesc": "TC with required GPU; TC with extra GPU requirements; 8 cores and 16GB RAM per task"
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",
         "CouchDBName": "reqmgr_config_cache",
@@ -67,6 +67,7 @@
             "EventsPerLumi": 100,
             "GPUParams": "{\"CUDACapabilities\": [\"6.0\", \"6.1\", \"6.2\", \"7.0\", \"7.2\", \"7.5\", \"8.0\", \"8.6\", \"8.7\", \"8.9\", \"9.0\", \"10.0\"], \"CUDARuntime\": \"12.0\", \"GPUMemoryMB\": 8000}",
             "GlobalTag": "142X_mcRun3_2025_realistic_v5",
+            "JobExtraMatchRequirements": "regexp(\"GenSimFull\", WMAgent_SubTaskName)",
             "KeepOutput": true,
             "Memory": 16000,
             "Multicore": 8,
@@ -89,6 +90,7 @@
             "EventStreams": 1,
             "GPUParams": "{\"CUDACapabilities\": [\"6.0\", \"6.1\", \"6.2\", \"7.0\", \"7.2\", \"7.5\", \"8.0\", \"8.6\", \"8.7\", \"8.9\", \"9.0\", \"10.0\"], \"CUDARuntime\": \"12.0\", \"GPUMemoryMB\": 8000}",
             "GlobalTag": "142X_mcRun3_2025_realistic_v5",
+            "JobExtraMatchRequirements": "regexp(\"Digi\", WMAgent_SubTaskName)",
             "InputFromOutputModule": "FEVTDEBUGoutput",
             "InputTask": "GenSimFull",
             "KeepOutput": true,
@@ -111,6 +113,7 @@
             "EventStreams": 1,
             "GPUParams": "{\"CUDACapabilities\": [\"6.0\", \"6.1\", \"6.2\", \"7.0\", \"7.2\", \"7.5\", \"8.0\", \"8.6\", \"8.7\", \"8.9\", \"9.0\", \"10.0\"], \"CUDARuntime\": \"12.0\", \"GPUMemoryMB\": 8000}",
             "GlobalTag": "142X_mcRun3_2025_realistic_v5",
+            "JobExtraMatchRequirements": "regexp(\"Reco\", WMAgent_SubTaskName)",
             "InputFromOutputModule": "FEVTDEBUGHLToutput",
             "InputTask": "Digi_Patatrack_PixelOnlyAlpaka_Validation_2025",
             "KeepOutput": true,


### PR DESCRIPTION
Fixes #12407 

#### Status
In development

#### Description
With this PR, WMAgent will be able to fetch the workflow level `jobExtraMatchRequirements` for user-provided extra matchmaking expression.
If it is provided, we then extend the job `Requirements` expression to include it as well.

UPDATE: modified 2 JSON templates with the new parameter, for testing and as a reference.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Changes made to central services: https://github.com/dmwm/WMCore/pull/12417

#### External dependencies / deployment changes
None