### PR TITLE
Fix failed calls of AgentStatusPoller.collectAgentInfo() for down components

### DIFF
--- a/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
+++ b/src/python/WMComponent/AnalyticsDataCollector/DataCollectAPI.py
@@ -301,15 +301,15 @@ class WMAgentDBData(object):
             if compPidTree:
                 agentComponents.update({component: processStatus(compPidTree['Parent'])})
 
-            badComponentThreads = list(set(compPidTree['LostThreads']) | set(compPidTree['OrphanThreads']))
+            badComponentThreads = list(set(compPidTree.get('LostThreads',[])) | set(compPidTree.get('OrphanThreads',[])))
             if downFlag and component not in agentInfo['down_components']:
                 agentInfo['status'] = 'down'
                 agentInfo['down_components'].append(component)
                 if badComponentThreads:
                     agentInfo['down_component_detail'].append(
                         downThreadsDetails(component,
-                                       compPidTree['Parent'],
-                                       compPidTree))
+                                           compPidTree.get('Parent', None),
+                                           compPidTree))
                 else:
                     agentInfo['down_component_detail'].append(component)
 


### PR DESCRIPTION
Fixes #12446

#### Status
ready

#### Description
when a component is a completely 'Down' any call to `wmcoreDTools.getComponentThreads()` would produce an empty dictionary. Upon that, if this is not accounted for and a subsequent call is made to any field from the so returned dictionary would result in an error. I checked all the code and the only place such a mistake was done was at  `DataCollectAPI.getComponentStatus()` which on its own was called only by `AgentStatusWatcher.collectAgentInfo()`. 

The end result was that at startup if `AgentStatusWatcher` happened to start not last but before any of the other components, it would simply throw a `KeyError: 'LostThreads'` exception and fail to ramp up. The good part, though, was that on the next iteration of `AgentWatchdogScanner` the `AgentStatusWatcher` would have been spotted to be in bad shape, then restarted, and would have fired up absolutely fine, but the agent status would have not been updated  at `wmstats` for one such full cycle. Nevertheless this is a not desirable behavior.      

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
https://github.com/dmwm/WMCore/pull/12382

#### External dependencies / deployment changes
None
