### PR TITLE
Rely on TagCollector caching in JobSubmitter

### DIFF
--- a/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
+++ b/src/python/WMComponent/JobSubmitter/JobSubmitterPoller.py
@@ -33,6 +33,7 @@ from WMCore.WMException import WMException
 from WMCore.BossAir.BossAirAPI import BossAirAPI
 from WMCore.Services.ReqMgr.ReqMgr import ReqMgr
 from WMCore.Services.ReqMgrAux.ReqMgrAux import ReqMgrAux
+from WMCore.Services.TagCollector.TagCollector import TagCollector
 
 from WMComponent.JobSubmitter.JobSubmitAPI import availableScheddSlots
 
@@ -103,6 +104,10 @@ class JobSubmitterPoller(BaseWorkerThread):
         self.drainSitesSet = set()
         self.abortSites = set()
         self.refreshPollingCount = 0
+
+        # TagCollector for getting the CMSSW micro-architectures
+        tcCacheHours = getattr(self.config.JobSubmitter, 'TagCollectorCacheHours', 3)
+        self.tc = TagCollector(configDict={'cacheduration': tcCacheHours})
 
         try:
             if not getattr(self.config.JobSubmitter, 'submitDir', None):
@@ -743,6 +748,15 @@ class JobSubmitterPoller(BaseWorkerThread):
             logging.debug("There are no packages to submit.")
             return
 
+        # Update cache of CMSSW micro-architectures
+        try:
+            cmsswMicroArchs = self.tc.defaultMicroArchVersionNumberByRelease()
+        except Exception as ex:
+            msg = f"Failed to update cache of CMSSW micro-architectures: {str(ex)}. "
+            msg += "Retrying again in the next cycle."
+            logging.error(msg)
+            return
+
         for package in jobsToSubmit:
             jobs = jobsToSubmit.get(package, [])
             for job in jobs:
@@ -755,7 +769,7 @@ class JobSubmitterPoller(BaseWorkerThread):
         myThread.transaction.begin()
 
         # Run the actual underlying submit code using bossAir
-        successList, failList = self.bossAir.submit(jobs=jobList)
+        successList, failList = self.bossAir.submit(jobs=jobList, info=cmsswMicroArchs)
         logging.info("Jobs that succeeded/failed submission: %d/%d.", len(successList), len(failList))
 
         # Propagate states in the WMBS database

--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -22,6 +22,7 @@ from WMCore.WMInit import getWMBASE
 from WMCore.Lexicon import getIterMatchObjectOnRegexp, WMEXCEPTION_REGEXP, CONDOR_LOG_FILTER_REGEXP
 from WMCore.Services.TagCollector.TagCollector import TagCollector
 
+
 def activityToType(jobActivity):
     """
     Function to map a workflow activity to a generic CMS job type.
@@ -138,7 +139,7 @@ class SimpleCondorPlugin(BasePlugin):
         # These are added now by the condor client
         #self.x509userproxysubject = proxy.getSubject()
         #self.x509userproxyfqan = proxy.getAttributeFromProxy(self.x509userproxy)
-        
+
         self.tc = TagCollector()
 
         self.useCMSToken = getattr(config.JobSubmitter, 'useOauthToken', False)
@@ -163,7 +164,7 @@ class SimpleCondorPlugin(BasePlugin):
         # Submit the jobs
         for jobsReady in grouper(jobs, self.jobsPerSubmit):
 
-            (sub, jobParams) = self.createSubmitRequest(jobsReady)
+            (sub, jobParams) = self.createSubmitRequest(jobsReady, cmsswMicroArchs=info)
 
             logging.debug("Start: Submitting %d jobs using Condor Python Submit", len(jobParams))
             try:
@@ -494,17 +495,17 @@ class SimpleCondorPlugin(BasePlugin):
         return
 
 
-    def getJobParameters(self, jobList):
+    def getJobParameters(self, jobList, cmsswMicroArchs=None):
         """
         _getJobParameters_
+        :param jobList: list of jobs to submit
+        :param cmsswMicroArchs: dictionary of CMSSW micro-architectures
 
         Return a list of dictionaries with submit parameters per job.
         """
 
         undefined = 'UNDEFINED'
         jobParameters = []
-        # fetch an up-to-date list of CMSSW micro-architectures
-        rel_microarchs = self.tc.defaultMicroArchVersionNumberByRelease()
 
         for job in jobList:
             ad = {}
@@ -666,7 +667,7 @@ class SimpleCondorPlugin(BasePlugin):
             if 'X86_64' not in requiredArchs.split(","):
                 ad['My.REQUIRED_MINIMUM_MICROARCH'] = "0"
             else:
-                minMicroArch = self.tc.getGreaterMicroarchVersionNumber(cmsswVersions, rel_microarchs=rel_microarchs)
+                minMicroArch = self.tc.getGreaterMicroarchVersionNumber(cmsswVersions, rel_microarchs=cmsswMicroArchs)
                 ad['My.REQUIRED_MINIMUM_MICROARCH'] = str(minMicroArch) 
 
             jobParameters.append(ad)
@@ -674,12 +675,13 @@ class SimpleCondorPlugin(BasePlugin):
         return jobParameters
 
 
-    def createSubmitRequest(self, jobList):
+    def createSubmitRequest(self, jobList, cmsswMicroArchs=None):
         """
         _createSubmitRequest_
+        :param jobList: list of jobs to submit
+        :param cmsswMicroArchs: dictionary of CMSSW micro-architectures
 
         Return the submit object to pass to htcondor.Submit()
-
         """
 
         sub = htcondor.Submit("""
@@ -710,6 +712,6 @@ class SimpleCondorPlugin(BasePlugin):
         sub['My.CMS_WMTool'] = classad.quote("WMAgent")
         sub['My.CMS_SubmissionTool'] = classad.quote("WMAgent")
 
-        jobParameters = self.getJobParameters(jobList)
+        jobParameters = self.getJobParameters(jobList, cmsswMicroArchs=cmsswMicroArchs)
 
         return sub, jobParameters


### PR DESCRIPTION
Fixes #12419 

#### Status
In development

#### Description
With this PR, we stop fetching TagCollector data for every job submission cycle.
Instead, create the TagCollector object upstream (at JobSubmitterPoller) and keep using that data as long as the cache is valid. In addition, the cache validity can be configured with a component configuration hook `config.JobSubmitter.TagCollectorCacheHours`


#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
