### PR TITLE
Enable python-oracledb ThickMode while keeping sqlalchemy on 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ CherryPy~=18.10.0             # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmgloba
 CMSCouchapp~=1.3.4            # wmcore,wmagent
 CMSMonitoring~=0.6.13         # wmcore,wmagent,reqmgr2,reqmon,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 coverage~=7.9.0               # wmcore,wmagent,wmagentdev
-cx-Oracle~=8.3.0              # wmcore,wmagent
+oracledb~=3.3.0               # wmcore,wmagent
 dbs3-client==4.0.19           # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,wmglobalqueue,msoutput,mstransferor
 future~=1.0.0                 # wmcore,wmagent,wmagentdev,reqmgr2,reqmon,acdcserver,wmglobalqueue,msunmerged,msoutput,mspileup,msmonitor,mstransferor,msrulecleaner
 gfal2-python~=1.11.0.post3    # wmcore,msunmerged

--- a/src/python/WMCore/Database/DBFactory.py
+++ b/src/python/WMCore/Database/DBFactory.py
@@ -1,8 +1,11 @@
-
+#pylint: disable=W0102
 from builtins import object
 import threading
 import sys
 import oracledb
+
+# NOTE: We need to ensure SQLAlchemy would be able to find the oracledb python libraries.
+#       Further details at: https://cjones-oracle.medium.com/using-python-oracledb-1-0-with-sqlalchemy-pandas-django-and-flask-5d84e910cb19
 oracledb.version = "8.3.0"
 sys.modules["cx_Oracle"] = oracledb
 oracledb.init_oracle_client()
@@ -11,7 +14,6 @@ oracledb.init_oracle_client()
 from sqlalchemy import create_engine
 from sqlalchemy import __version__ as sqlalchemy_version
 from WMCore.Database.Dialects import MySQLDialect
-from WMCore.Database.Dialects import OracleDialect
 
 class DBFactory(object):
 
@@ -30,18 +32,17 @@ class DBFactory(object):
         if dburl:
             self.dburl = dburl
         else:
-            #This will be deprecated.
-            """
-            Need to make the dburl here. Possible formats are:
+            # NOTE: This will be deprecated.
+            #
+            #       Need to make the dburl here. Possible formats are:
 
-            mysql://host/database
-            mysql://username@host/database
-            mysql://username:password@host:port/database
+            #       mysql://host/database
+            #       mysql://username@host/database
+            #       mysql://username:password@host:port/database
 
-            oracle://username:password@tnsName
-            oracle://username:password@host:port/sidname
+            #       oracle://username:password@tnsName
+            #       oracle://username:password@host:port/sidname
 
-            """
             hostjoin = ''
             if 'dialect' in options:
                 self.dburl = '%s://' % options['dialect']

--- a/src/python/WMCore/Database/DBFactory.py
+++ b/src/python/WMCore/Database/DBFactory.py
@@ -1,6 +1,12 @@
 
 from builtins import object
 import threading
+import sys
+import oracledb
+oracledb.version = "8.3.0"
+sys.modules["cx_Oracle"] = oracledb
+oracledb.init_oracle_client()
+
 
 from sqlalchemy import create_engine
 from sqlalchemy import __version__ as sqlalchemy_version


### PR DESCRIPTION
Fixes #12395 

#### Status

Ready

#### Description
With the current  PR we enable python-oracledb ThickMode + sqlalchemy  1.4


#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
* Adding Oracle instant client libraries to the docker images we run at Jenkins: [#CMSKubernetes/1663](https://github.com/dmwm/CMSKubernetes/pull/1663)
* Resolving the `libaio` library issue at image build time rather on runtime:  [#CMSKubernetes/1667](https://github.com/dmwm/CMSKubernetes/pull/1667) [#CMSKubernetes/1672](https://github.com/dmwm/CMSKubernetes/pull/1672)
* Ramping up Oracle instant client version to 23: [#CMSKubernetes/1668](https://github.com/dmwm/CMSKubernetes/pull/1668)
* Switching `wmagent-base` and `wmagent` images to use the latest `oracle` image uploaded  to CERN Registry && remove the `libaio` runtime workaround: [#CMSKubernetes/1670](https://github.com/dmwm/CMSKubernetes/pull/1670)

#### External dependencies / deployment changes
This PR introduces  a new OS level dependency, which must be enforced also to our `wmcore-dev` images which we run within our  Jenkins  setup. The new  image is switched to at the configuration of this Jenkins job: https://cmssdt.cern.ch/dmwm-jenkins/job/WMCore-PR-Test/ 
