### PR TITLE
Revisit timeout alarm during StageOut, ensuring child process is killed

### DIFF
--- a/src/python/WMCore/Storage/StageOutImpl.py
+++ b/src/python/WMCore/Storage/StageOutImpl.py
@@ -36,6 +36,7 @@ class StageOutImpl:
     def __init__(self, stagein=False):
         self.numRetries = 3
         self.retryPause = 600
+        self.timeout = 3600 * self.numRetries
         self.stageIn = stagein
         self.debuggingTemplate =  "#!/bin/bash\n"
         self.debuggingTemplate += """
@@ -121,14 +122,13 @@ class StageOutImpl:
 
     def executeCommand(self, command):
         """
-        _execute_
-
         Execute the command provided, throw a StageOutError if it exits
         non zero
-
+        :param command: string with the command to execute
         """
         try:
-            exitCode, output = runCommandWithOutput(command)
+            logging.info("Executing command with timeout: %s seconds", self.timeout)
+            exitCode, output = runCommandWithOutput(command, timeout=self.timeout)
             msg = "Command exited with status: {}\nOutput message: {}".format(exitCode, output)
             logging.info(msg)
         except Exception as ex:

--- a/test/python/WMCore_t/Storage_t/Execute_t.py
+++ b/test/python/WMCore_t/Storage_t/Execute_t.py
@@ -48,3 +48,19 @@ class ExecuteTest(unittest.TestCase):
         self.assertEqual((1, 'stdout: \nstderr: a\n'), runCommandWithOutput("%s %s -exit a" % (self.python_runtime, self.base)))
         self.assertEqual((0, 'stdout: a\n\nstderr: '), runCommandWithOutput("%s %s -text a" % (self.python_runtime, self.base)))
 
+    def testRunCommandWithOutput_timeout(self):
+        """
+        Test that runCommandWithOutput properly handles timeouts by killing child processes
+        and returning appropriate output with timeout message.
+        """
+        long_running_cmd = "sleep 5 && echo done"
+        # Test with a 1 second timeout - should trigger timeout
+        exit_code, output = runCommandWithOutput(long_running_cmd, timeout=1)
+
+        # Verify the timeout was handled
+        self.assertIn("Command reached timeout of 1 seconds", output)
+        self.assertIn("and child process was killed", output)
+        self.assertIn("Terminated by signal", output)
+
+        # The exit code should be negative (indicating termination by signal) 9 is SIGKILL
+        self.assertEqual(exit_code, -9)

--- a/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
+++ b/test/python/WMCore_t/Storage_t/StageOutImpl_t.py
@@ -45,7 +45,7 @@ class StageOutImplTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             self.StageOutImpl.executeCommand("command")
             self.assertTrue('ErrorCode : 60311' in context.exception)
-        mock_runCommand.assert_called_with("command")
+        mock_runCommand.assert_called_with("command", timeout=10800)
 
     @mock.patch('WMCore.Storage.StageOutImpl.runCommandWithOutput')
     def testExecuteCommand_exitCode(self, mock_runCommand):
@@ -53,13 +53,13 @@ class StageOutImplTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             self.StageOutImpl.executeCommand("command")
             self.assertTrue('ErrorCode : 1' in context.exception)
-        mock_runCommand.assert_called_with("command")
+        mock_runCommand.assert_called_with("command", timeout=10800)
 
     @mock.patch('WMCore.Storage.StageOutImpl.runCommandWithOutput')
     def testExecuteCommand_valid(self, mock_runCommand):
         mock_runCommand.return_value = 0, "Test Success"
         self.StageOutImpl.executeCommand("command")
-        mock_runCommand.assert_called_with("command")
+        mock_runCommand.assert_called_with("command", timeout=10800)
 
     @mock.patch('WMCore.Storage.StageOutImpl.os.path')
     def testCreateRemoveFileCommand_isFile(self, mock_path):
@@ -179,3 +179,4 @@ class StageOutImplTest(unittest.TestCase):
             os.environ["BEARER_TOKEN_FILE"] = temp_file_path
             self.assertTrue(self.StageOutImpl.isBearerTokenFileSet())
         del os.environ["BEARER_TOKEN_FILE"]
+


### PR DESCRIPTION
Fixes #12439 

#### Status
not-tested

#### Description
According to the source code and `subprocess` documentation, raising an alarm would leave the child process behind.
Hence, instead of using the signal handling at an upper class, bring the timeout close to the subprocess call, such that we can properly terminate (SIGTERM) or kill (SIGKILL) the child process. In this case, I decided to use the SIGKILL signal to ensure that the child process is really done. 

Note that stage out timeout has been reduced from `2h * numRetries` to `1h * numRetries`, which by default would allow the stage out command to run for up to 3h. For example, a 4GB file would have to have a average transfer rate lower than .38MB/s to hit this limit.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Subprocess documentation: https://docs.python.org/3.12/library/subprocess.html#subprocess.Popen.communicate

#### External dependencies / deployment changes
None
