### PR TITLE
WMAgent: Make AgentWatchdog configurable

### DIFF
--- a/etc/WMAgentConfig.py
+++ b/etc/WMAgentConfig.py
@@ -467,8 +467,10 @@ config.WorkflowUpdater.msPileupUrl = "OVER_WRITE_BY_SECRETS"
 
 config.component_("AgentWatchdog")
 config.AgentWatchdog.section_('AgentWatchdogPoller')
+config.AgentWatchdog.AgentWatchdogPoller.enabled = True
 config.AgentWatchdog.AgentWatchdogPoller.pollInterval = 20
 config.AgentWatchdog.section_('AgentWatchdogScanner')
+config.AgentWatchdog.AgentWatchdogScanner.enabled = True
 config.AgentWatchdog.AgentWatchdogScanner.pollInterval = 60 * 60
 config.AgentWatchdog.namespace = "WMComponent.AgentWatchdog.AgentWatchdog"
 config.AgentWatchdog.componentDir = config.General.workDir + "/AgentWatchdog"

--- a/src/python/WMComponent/AgentWatchdog/AgentWatchdog.py
+++ b/src/python/WMComponent/AgentWatchdog/AgentWatchdog.py
@@ -57,17 +57,18 @@ class AgentWatchdog(Harness):
         agentWatchdogScannerInterval = self.config.AgentWatchdog.AgentWatchdogScanner.pollInterval
         currThread = threading.currentThread()
 
-        if not hasattr(self.config, "Tier0Feeder"):
+        if getattr(self.config.AgentWatchdog.AgentWatchdogPoller, 'enabled', False):
             logging.info("Setting AgentWatchdogPoller poll interval to %s seconds", agentWatchdogPollerInterval)
             agentWatchdogPollerThread = currThread.workerThreadManager.addWorker(AgentWatchdogPoller(self.config),
                                                                              agentWatchdogPollerInterval)
             logging.info(f"AgentWatchdog thread PID: {currThread.native_id}")
             logging.info(f"AgentWatchdogPoller thread PID: {agentWatchdogPollerThread.native_id}")
 
+        if getattr(self.config.AgentWatchdog.AgentWatchdogScanner, 'enabled', False):
             logging.info("Setting AgentWatchdogScanner poll interval to %s seconds", agentWatchdogScannerInterval)
             agentWatchdogScannerThread = currThread.workerThreadManager.addWorker(AgentWatchdogScanner(self.config),
                                                                              agentWatchdogScannerInterval)
             logging.info(f"AgentWatchdog thread PID: {currThread.native_id}")
-            logging.info(f"AgentWatchdogPoller thread PID: {agentWatchdogPollerThread.native_id}")
+            logging.info(f"AgentWatchdogScanner thread PID: {agentWatchdogScannerThread.native_id}")
 
         return

--- a/src/python/WMComponent/AgentWatchdog/AgentWatchdog.py
+++ b/src/python/WMComponent/AgentWatchdog/AgentWatchdog.py
@@ -10,7 +10,6 @@ of the health of all WMAgent components.
 
 import logging
 import threading
-import time
 
 from WMCore.Agent.Harness import Harness
 from WMComponent.AgentWatchdog.AgentWatchdogPoller import AgentWatchdogPoller
@@ -55,20 +54,20 @@ class AgentWatchdog(Harness):
         #       agentWatchdogPollInterval = self.config.AgentWatchdog.pollInterval
         agentWatchdogPollerInterval = 0
         agentWatchdogScannerInterval = self.config.AgentWatchdog.AgentWatchdogScanner.pollInterval
-        currThread = threading.currentThread()
+        currThread = threading.current_thread()
 
         if getattr(self.config.AgentWatchdog.AgentWatchdogPoller, 'enabled', False):
             logging.info("Setting AgentWatchdogPoller poll interval to %s seconds", agentWatchdogPollerInterval)
             agentWatchdogPollerThread = currThread.workerThreadManager.addWorker(AgentWatchdogPoller(self.config),
                                                                              agentWatchdogPollerInterval)
-            logging.info(f"AgentWatchdog thread PID: {currThread.native_id}")
-            logging.info(f"AgentWatchdogPoller thread PID: {agentWatchdogPollerThread.native_id}")
+            logging.info("AgentWatchdog thread PID: %s", currThread.native_id)
+            logging.info("AgentWatchdogPoller thread PID: %s", agentWatchdogPollerThread.native_id)
 
         if getattr(self.config.AgentWatchdog.AgentWatchdogScanner, 'enabled', False):
             logging.info("Setting AgentWatchdogScanner poll interval to %s seconds", agentWatchdogScannerInterval)
             agentWatchdogScannerThread = currThread.workerThreadManager.addWorker(AgentWatchdogScanner(self.config),
                                                                              agentWatchdogScannerInterval)
-            logging.info(f"AgentWatchdog thread PID: {currThread.native_id}")
-            logging.info(f"AgentWatchdogScanner thread PID: {agentWatchdogScannerThread.native_id}")
+            logging.info("AgentWatchdog thread PID: %s", currThread.native_id)
+            logging.info("AgentWatchdogScanner thread PID: %s", agentWatchdogScannerThread.native_id)
 
         return

--- a/src/python/WMComponent/AgentWatchdog/AgentWatchdogPoller.py
+++ b/src/python/WMComponent/AgentWatchdog/AgentWatchdogPoller.py
@@ -112,7 +112,10 @@ class AgentWatchdogPoller(BaseWorkerThread):
         summary = f"Alert from WMAgent {currAgent}"
         description = alertMessage
         service = f"AgentWatchdogPoller@{currAgent}"
-        self.alertManager.sendAlert(alertName, severity, summary, description, service, tag=self.alertDestinationMap['alertAgentWatchdogPoller'])
+        try:
+            self.alertManager.sendAlert(alertName, severity, summary, description, service, tag=self.alertDestinationMap['alertAgentWatchdogPoller'])
+        except Exception as ex:
+            logging.error(f"Could not send alert. Error type:{type(ex)}: {ex.args}")
 
     def alertAction(self, timerName):
         """

--- a/src/python/WMComponent/AgentWatchdog/AgentWatchdogScanner.py
+++ b/src/python/WMComponent/AgentWatchdog/AgentWatchdogScanner.py
@@ -72,7 +72,10 @@ class AgentWatchdogScanner(BaseWorkerThread):
         summary = f"Alert from WMAgent {currAgent}"
         description = alertMessage
         service = f"AgentWatchdogScanner@{currAgent}"
-        self.alertManager.sendAlert(alertName, severity, summary, description, service, tag=self.alertDestinationMap['alertAgentWatchdogScanner'])
+        try:
+            self.alertManager.sendAlert(alertName, severity, summary, description, service, tag=self.alertDestinationMap['alertAgentWatchdogScanner'])
+        except Exception as ex:
+            logging.error(f"Could not send alert. Error type:{type(ex)}: {ex.args}")
 
     def checkCompAlive(self):
         """


### PR DESCRIPTION
Fixes #12307

#### Status
ready

#### Description
With the current PR we are making the process of Enabling/Disabling the `AgnetWatchdog` component's threads configurable. Each of the two threads: `AgentWatchdogPoller` and `AgentWatchdogSccanner`  serve different purposes and run independently, so they'd  deserve a separate enable/disable flag. 

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
We are about to remove the cronjob for calling the old restart_component script:
https://github.com/dmwm/CMSKubernetes/pull/1671

#### External dependencies / deployment changes
None