### PR TITLE
Real minor updates to JSON workflow templates

### DIFF
--- a/test/data/ReqMgr/requests/DMWM/ReReco_RunBlocklists_Parents.json
+++ b/test/data/ReqMgr/requests/DMWM/ReReco_RunBlocklists_Parents.json
@@ -29,7 +29,7 @@
             "CheckList": ["ReReco workflow; ReReco with IncludeParents; ReReco with run whitelist;",
                           "ReReco with block whitelist; ReReco multicore; ReReco with TrustSitelists enabled"],
             "WorkFlowDesc": ["ReReco MINIAOD with 3 blocks whitelisted; but only 2 blocks processed out of 4 runs whitelisted;",
-                             "Including 4 AOD parent blocks; Running with 2 cores and 3GB of memory"]
+                             "Including 4 AOD parent blocks; Running with 2 cores and 4GB of memory"]
         },
         "ConfigCacheID": "544d8059f5f200f8959e2e4fab11a94e",
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",

--- a/test/data/ReqMgr/requests/DMWM/SC_ProdPsi.json
+++ b/test/data/ReqMgr/requests/DMWM/SC_ProdPsi.json
@@ -37,11 +37,11 @@
         "Campaign": "Campaign-OVERRIDE-ME",
         "Comments": {
             "CheckList": [
-                "StepChain MC from scratch; StepChain extension; StepChain with transient Step2 GEN-SIM-DIGI-RAW output;  ",
-                "MC harvesting; Automatic EventBased and EventAwareLumiBased splitting; StepChain Disk and Tape rules "
+                "StepChain MC from scratch; StepChain MC extension; StepChain with transient Step2 GEN-SIM-DIGI-RAW output;  ",
+                "StepChain MC harvesting; Automatic EventBased splitting; StepChain Disk and Tape rules "
             ],
             "WorkFlowDesc": [
-                "SC MC from scratch; EventBased splitting with 700EpJ; FirstLumi=101; Rucio container rule for Disk"
+                "SC MC from scratch; EventBased splitting with 1100EpJ; FirstLumi=101; Rucio container rule for Disk"
             ]
         },
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb",

--- a/test/data/ReqMgr/requests/DMWM/TC_ProdPsi.json
+++ b/test/data/ReqMgr/requests/DMWM/TC_ProdPsi.json
@@ -32,10 +32,10 @@
         "CMSSWVersion": "CMSSW_12_0_0", 
         "Campaign": "Campaign-OVERRIDE-ME", 
         "Comments": {
-            "CheckList": ["TaskChain MC from scratch; TaskChain extension; TaskChain with transient Task2 GEN-SIM-DIGI-RAW output;  ",
-                          "MC harvesting; Automatic EventBased and EventAwareLumiBased splitting; TaskChain Disk and Tape rules "],
-            "WorkFlowDesc": ["TC MC from scratch without PU; Task1 with 300EpJ instead of 261EpJ; Task2 with 320EpJ; Task3 with 480;",
-                             "Task2/3 with EventAwareLumiBased; FirstEvent=10001, FirstLumi=101; Rucio container rule for Disk"]
+            "CheckList": ["TaskChain MC from scratch; TaskChain MC extension; TaskChain with transient Task2 GEN-SIM-DIGI-RAW output; SubRequestType=Extension ",
+                          "TaskChain MC harvesting; Automatic EventBased and EventAwareLumiBased splitting; TaskChain Disk and Tape rules "],
+            "WorkFlowDesc": ["TC MC from scratch without PU; Task1 with 400EpJ instead of 380EpJ; Task2 with 480EpJ; Task3 with 720;",
+                             "Task2/3 with EventAwareLumiBased; FirstEvent=10001, FirstLumi=101; Rucio container rule for Disk; SubRequestType=Extension"]
         }, 
         "ConfigCacheUrl": "https://cmsweb.cern.ch/couchdb", 
         "CouchDBName": "reqmgr_config_cache", 
@@ -61,7 +61,7 @@
             "slc7_amd64_gcc900"
         ], 
         "SizePerEvent": 1, 
-        "SubRequestType": "RelVal", 
+        "SubRequestType": "Extension", 
         "Task1": {
             "AcquisitionEra": "CMSSW_12_0_0", 
             "CMSSWVersion": "CMSSW_12_0_0", 


### PR DESCRIPTION
Fixes (no issue created)

#### Status
ready

#### Description
Changes provided are:
* correct some comments/checklist (in light of the new pilot target time 8h -> 12h)
* convert one template from `SubRequestType=Extension`

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None