### PR TITLE
Set Harvest memory requirements in the JobFactory

### DIFF
--- a/src/python/WMCore/JobSplitting/Harvest.py
+++ b/src/python/WMCore/JobSplitting/Harvest.py
@@ -150,6 +150,7 @@ class Harvest(JobFactory):
             if endOfRun:
                 self.currentJob.addBaggageParameter("runIsComplete", True)
             self.mergeLumiRange(self.currentJob['mask']['runAndLumis'])
+            self.currentJob.addResourceEstimates(memory=self.memoryReq)
         return
 
     def createMultiRunJob(self, locationDict, location, baseName, harvestType, runDict, endOfRun):
@@ -174,6 +175,7 @@ class Harvest(JobFactory):
         if endOfRun:
             self.currentJob.addBaggageParameter("runIsComplete", True)
         self.mergeLumiRange(self.currentJob['mask']['runAndLumis'])
+        self.currentJob.addResourceEstimates(memory=self.memoryReq)
 
         # now calculate the minimum and maximum run number, it has to go to the root name
         minRun = min(self.currentJob['mask']['runAndLumis'].keys())
@@ -216,6 +218,7 @@ class Harvest(JobFactory):
         runWhitelist = set(kwargs.get('runWhitelist', []))
         runBlacklist = set(kwargs.get('runBlacklist', []))
         goodRunList = runWhitelist.difference(runBlacklist)
+        _tpEvt, _spEvt, self.memoryReq = self.getPerformanceParameters(kwargs.get('performance', {}))
 
         daoFactory = DAOFactory(package="WMCore.WMBS",
                                 logger=myThread.logger,


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11364
Complement to https://github.com/dmwm/WMCore/pull/12404

#### Status
ready

#### Description
Make a call to the resource estimates (consuming the WMTask object) whenever a Harvest job is created, hence propagating the memory requirements down to the job object/pickle.

PS: second commit does not seem to help with unit tests. If confirmed, it has to be removed before merging it.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Fix a missing development in https://github.com/dmwm/WMCore/pull/12404

#### External dependencies / deployment changes
None
