### PR TITLE
Add support for ScitagConfig tweak in SetupCMSSWPset for CMSSW >= 16_0_0

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -591,9 +591,12 @@ class SetupCMSSWPset(ScriptInterface):
 
         self.logger.info("Enabling ScitagConfig with productionCase for CMSSW version: %s", cmsswVersion)
         tweak = PSetTweak()
-        tweak.addParameter("process.ScitagConfig",
-                           "customTypeCms.Service('ScitagConfig', productionCase=cms.untracked.bool(True))")
+        tweak.addParameter("process.ScitagConfig", "customTypeCms.Service('ScitagConfig')")
         self.applyPsetTweak(tweak, skipIfSet=True)
+
+        tweak = PSetTweak()
+        tweak.addParameter("process.ScitagConfig.productionCase", "customTypeCms.untracked.bool(True)")
+        self.applyPsetTweak(tweak)
 
         return
 


### PR DESCRIPTION


Related to https://github.com/cms-sw/cmssw/issues/47517


#### Status
In development

#### Description
PSet tweak to add support for "Production Input" case for SciToken packet labelling. 
https://github.com/cms-sw/cmssw/issues/47517#issuecomment-3778997974

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
No

#### External dependencies / deployment changes
CMSSW https://github.com/cms-sw/cmssw/pull/49740
