### PR TITLE
Fix block record creation in updateBlockInfo function to be consistent

### DIFF
--- a/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
+++ b/src/python/WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py
@@ -169,7 +169,7 @@ def updateBlockInfo(jdoc, msPUBlockLoc, dbsUrl, logger):
         for blockName in msPUBlockLoc.keys():
             if blockName not in list(jdoc[puType].keys()):
                 # add block record from MSPileup
-                record = {blockName: {"PhEDExNodeNames": msPUBlockLoc[blockName]}}
+                record = {"PhEDExNodeNames": msPUBlockLoc[blockName]}
                 newDict[blockName] = record
                 # keep track of blocks we need to update with DBS information
                 blocksToUpdate.append(blockName)


### PR DESCRIPTION
Fixes #12480 

#### Status
in development

#### Description
Applied in `WMComponent/WorkflowUpdater/WorkflowUpdaterPoller.py:172`. The fix corrects the record
structure for new blocks added from MSPileup so that `PhEDExNodeNames` is at the top level of the
block entry, consistent with the structure written by `PileupFetcher` and expected by
`SetupCMSSWPset.handlePileup()`.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA
