### PR TITLE
Update setuptools version constraint in CI

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Upgrade pip3 and install build tools
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools wheel
+          python3 -m pip install "setuptools>=45,<82" wheel
 
       # create appropriate setup.py for python builds
       - name: Update the setup script template with package name


### PR DESCRIPTION


Fixes #12483

#### Status
ready

#### Description
Change to Gtihub Pipeline for building and publishing python packages.


Recent releases of setuptools (v81.0.0+), including v82.0.0, removed the bundled pkg_resources module that many legacy build scripts still import. In our CI build for rucio-clients and other dependencies this causes wheel builds to fail with “ModuleNotFoundError: No module named 'pkg_resources'”. upstream setuptools release notes confirm that pkg_resources has been removed as of setuptools 82.0.0 and that users should pin to <81 until packages migrate away from pkg_resources. see setuptools https://setuptools.pypa.io/en/stable/history.html#v82-0-0

Update workflow to install “setuptools>=45,<80” instead of the latest to ensure compatibility with existing setup.py code during wheel builds.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA
