### PR TITLE
Support L1Scouting PDs to have their own merging for nanoaod 

### DIFF
--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -687,6 +687,7 @@ class StdBase(object):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
+        primaryDataset = getattr(parentOutputModule, "primaryDataset")
         dataTier = getattr(parentOutputModule, "dataTier")
         mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
@@ -715,8 +716,12 @@ class StdBase(object):
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
                                                          newDQMIO=True)
         elif dataTier in ("NANOAOD", "NANOAODSIM"):
-            mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
-                                                         mergeNANO=True)
+            if primaryDataset in ("L1Scouting", "L1ScoutingSelection"):
+                mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
+                                                            mergeL1SCOUTNANO=True)                
+            else:
+                mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
+                                                            mergeNANO=True)
         else:
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
 

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -711,24 +711,21 @@ class StdBase(object):
                                         max_wait_time=self.maxWaitTime,
                                         initial_lfn_counter=lfn_counter)
 
+        primaryDataset = getattr(parentOutputModule, "primaryDataset")
         if dataTier == "DQMIO":
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
                                                          newDQMIO=True)
         elif dataTier in ("NANOAOD", "NANOAODSIM"):
-            primaryDataset = getattr(parentOutputModule, "primaryDataset", "")
-            if primaryDataset.startswith("L1Scouting"):
-                mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
-                                                            mergeL1SCOUTNANO=True)                
-            else:
-                mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
-                                                            mergeNANO=True)
+            mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
+                                                     mergeNANO=True,
+                                                     isL1Scouting=(primaryDataset.startswith("L1Scouting")))
         else:
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge")
 
         mergeTaskStageHelper.setMinMergeSize(0, 0)
 
         self.addOutputModule(mergeTask, "Merged",
-                             primaryDataset=getattr(parentOutputModule, "primaryDataset"),
+                             primaryDataset=primaryDataset,
                              dataTier=getattr(parentOutputModule, "dataTier"),
                              filterName=getattr(parentOutputModule, "filterName"),
                              forceMerged=True, taskConf=taskConf)

--- a/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
+++ b/src/python/WMCore/WMSpec/StdSpecs/StdBase.py
@@ -687,7 +687,6 @@ class StdBase(object):
         parentTaskCmssw = parentTask.getStep(parentStepName)
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)
 
-        primaryDataset = getattr(parentOutputModule, "primaryDataset")
         dataTier = getattr(parentOutputModule, "dataTier")
         mergeTask.setInputReference(parentTaskCmssw, outputModule=parentOutputModuleName, dataTier=dataTier)
 
@@ -716,7 +715,8 @@ class StdBase(object):
             mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
                                                          newDQMIO=True)
         elif dataTier in ("NANOAOD", "NANOAODSIM"):
-            if primaryDataset in ("L1Scouting", "L1ScoutingSelection"):
+            primaryDataset = getattr(parentOutputModule, "primaryDataset", "")
+            if primaryDataset.startswith("L1Scouting"):
                 mergeTaskCmsswHelper.setDataProcessingConfig("do_not_use", "merge",
                                                             mergeL1SCOUTNANO=True)                
             else:


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
Ready

#### Description
<Description of the changes proposed.>
L1 Scouting team wants to have tailored nano for their own usecase. The way we plan to handle this request is to use a different `mergeNANO` flag, namely `mergeL1SCOUTNANO` for their PDs `L1Scouting` and `L1ScoutingSelection`.

##### Update: we have decided not to use the `mergeL1SCOUTNANO` as a flag, since @missirol figured out a cleaner way to handle the identification of L1Scouting PDs. We now use a new flag `isL1scouting`, which will be evaluated in CMSSW before the merging algorithm is selected. See [cmssw/Merge.py](https://github.com/cms-sw/cmssw/blob/CMSSW_16_0_X/Configuration/DataProcessing/python/Merge.py#L74-#L87)

This PR needs a CMSSW PR such that the new flag is used here:
   * https://github.com/cms-sw/cmssw/pull/50511

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
Pending CMSSW PRs

#### External dependencies / deployment changes
None
