### PR TITLE
Handle corrupted Report.pkl gracefully in RetryManager to prevent component crash

### DIFF
--- a/src/python/WMComponent/RetryManager/PlugIns/PauseAlgo.py
+++ b/src/python/WMComponent/RetryManager/PlugIns/PauseAlgo.py
@@ -52,6 +52,15 @@ class PauseAlgo(RetryAlgoBase):
                     msg += str(ex)
                     logging.warning(msg)
 
+                except Exception as ex:
+                    msg = "Unknown error %s\n" % (reportPath)
+                    msg += str(ex)
+                    logging.warning(msg)
+                    retryByTimeOut = True
+                    pauseCount = 1
+                    logging.info("Started force retry three times")
+
+
         # Here introduces the SquaredAlgo logic :
         baseTimeoutDict = self.getAlgoParam(job['jobType'])
         baseTimeout = baseTimeoutDict.get(cooloffType.lower(), 10)


### PR DESCRIPTION
Fixes #12414

#### Status
ready

#### Description
When PauseAlgo.isReady() fails to unpickle a corrupted Report.pkl, the exception crashes the entire RetryManagerPoller thread, blocking retries for all jobs in cooloff — not just the affected one.
This fix wraps the plugin.isReady() call in selectRetryAlgo() with a try/except so that pickle failures are logged as warnings and the job proceeds with retry (skipping exit code check) instead of crashing the component.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
None

#### External dependencies / deployment changes
None
