### PR TITLE
Add setuptools constraint for CI for setuptools<80

### DIFF
--- a/.github/workflows/pypi_build_and_images.yaml
+++ b/.github/workflows/pypi_build_and_images.yaml
@@ -52,11 +52,13 @@ jobs:
           sudo apt update
           sudo apt install -y curl libcurl4-openssl-dev
 
-      # upgrade pip
+      # upgrade pip and set setuptools constraint for build isolation
       - name: Upgrade pip3 and install build tools
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "setuptools>=45,<82" wheel
+          echo 'setuptools<80' > /tmp/constraints.txt
+          echo "PIP_CONSTRAINT=/tmp/constraints.txt" >> "$GITHUB_ENV"
+          python3 -m pip install setuptools wheel
 
       # create appropriate setup.py for python builds
       - name: Update the setup script template with package name


### PR DESCRIPTION

Fixes #12483

#### Status
ready

#### Description
Small change in CI to use specific version of setuptools while installing requirments.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
NA

#### External dependencies / deployment changes
NA