### PR TITLE
fix: JobSubmitter lumi list index out of range

### DIFF
--- a/src/python/WMCore/JobSplitting/EventBased.py
+++ b/src/python/WMCore/JobSplitting/EventBased.py
@@ -216,6 +216,16 @@ class EventBased(JobFactory):
                     # the original and the ACDC workflow
                     # Lumis to recover are not necessarily sequential
                     acdcFile["lumis"] = acdcFile["lumis"][lumisPerJob:]
+                    if not acdcFile["lumis"]:
+                        # ran out of lumis while events remain: the ACDC doc has more
+                        # events than its lumi list can cover (e.g. double-counted events
+                        # from a partial lumi overlap merge). Skip the remainder instead of
+                        # crashing the whole JobCreator poller.
+                        logging.error("ACDC file %s for workflow %s ran out of lumis with "
+                                      "%d events still to run; skipping remaining events.",
+                                      acdcFile['lfn'], self.subscription.workflowName(),
+                                      eventsToRun)
+                        break
                     currentLumi = acdcFile["lumis"][0]
                     self.newJob(name=self.getJobName(length=totalJobs))
                     self.currentJob.addFile(fakeFile)


### PR DESCRIPTION
Fixes [#<Jira ticket>](https://its.cern.ch/jira/browse/CMSPROD-410)

#### Status
not-tested

#### Description
Component JobSubmitter throws an error when the lumi list is exhausted while eventsToRun is still positive, lumis[0] throws list index out of range. That happens whenever the ACDC doc's events count is larger than what its lumis list can cover.

#### Is it backward compatible (if not, which system it affects?)
YES