### PR TITLE
Change the registry to cmswmcore

### DIFF
--- a/.github/workflows/docker_images_template.yaml
+++ b/.github/workflows/docker_images_template.yaml
@@ -36,6 +36,8 @@ jobs:
         env:
           PYPI_TAG: ${{steps.get-ref.outputs.tag}}
           CERN_REGISTRY: registry.cern.ch
+          # Team-owned Harbor project namespace (replaces the shared cmsweb one)
+          CERN_PROJECT: cmswmcore
         run: |
           echo "Building service: ${SERVICE_NAME}, with tag: ${PYPI_TAG}"
           git clone --filter=blob:none --no-checkout https://github.com/dmwm/CMSKubernetes.git \
@@ -49,6 +51,6 @@ jobs:
           curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/master/bin/docker.sh
           chmod +x docker.sh
           echo "build new image"
-          ./docker.sh build ${SERVICE_NAME} ${PYPI_TAG} ${CERN_REGISTRY}
+          ./docker.sh build ${SERVICE_NAME} ${PYPI_TAG} ${CERN_REGISTRY} ${CERN_PROJECT}
           echo "push new image"
-          ./docker.sh push ${SERVICE_NAME} ${PYPI_TAG} ${CERN_REGISTRY}
+          ./docker.sh push ${SERVICE_NAME} ${PYPI_TAG} ${CERN_REGISTRY} ${CERN_PROJECT}

--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -2,9 +2,10 @@
 # Author: Valentin Kuznetsov <vkuznet@gmail.com>
 # helper script to handle docker actions
 
-if [ $# -ne 4 ]; then
-     echo "Usage: docker.sh <action> <service> <tag> <registry> "
+if [ $# -lt 4 ] || [ $# -gt 5 ]; then
+     echo "Usage: docker.sh <action> <service> <tag> <registry> [project]"
      echo "Supported actions: build, push"
+     echo "  project: Harbor project namespace, defaults to 'cmsweb'"
      exit 1;
 fi
 
@@ -25,7 +26,10 @@ action=$1
 service=$2
 tag=$3
 registry=$4
-rurl=$registry/cmsweb/$service
+# Harbor project namespace; optional 5th arg, defaults to cmsweb for backward
+# compatibility. WMCore CI now passes the team-owned project (cmswmcore).
+project=${5:-cmsweb}
+rurl=$registry/$project/$service
 
 # check if action is supported
 case "$action" in


### PR DESCRIPTION
#### Status
<not-tested >

#### Description
We need to change to a new registry (from cmsweb to cmswmcore). This is due to security concerns from CMS Web Serv & Security about the registry projects sharing robot accounts that see all images inside. 

#### Is it backward compatible (if not, which system it affects?)
YES. We only push to a new registry project, functionalities stay the same.

#### External dependencies / deployment changes
The deployment stays the same. The new registry lives here https://registry.cern.ch/harbor/projects/4084/summary.
