### PR TITLE
Add LHE workflow check

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
+++ b/src/python/WMCore/WMRuntime/Scripts/SetupCMSSWPset.py
@@ -495,7 +495,7 @@ class SetupCMSSWPset(ScriptInterface):
 
         if getattr(self.jobBag, "lheInputFiles", False):
             self.logger.info("Enabling 'lazy-download' for lheInputFiles job")
-            self._enableLazyDownload()
+            self._enableLazyDownload(checkLHEWorkflow=True)
 
         return
 
@@ -509,7 +509,7 @@ class SetupCMSSWPset(ScriptInterface):
         self._enableLazyDownload()
         return
 
-    def _enableLazyDownload(self):
+    def _enableLazyDownload(self, checkLHEWorkflow=False):
         """
         _enableLazyDownload_
 
@@ -520,6 +520,8 @@ class SetupCMSSWPset(ScriptInterface):
             procScript,
             os.path.join(self.stepSpace.location, self.configPickle),
             os.path.join(self.stepSpace.location, self.configPickle))
+        if checkLHEWorkflow:
+            cmd += " --check_lhe_workflow"
         self.scramRun(cmd)
 
         return


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/51060

#### Status
not-tested

#### Description
If LHE workflow, pass agrument to cmssw_enable_lazy_download.py
The goal is to limit lazy-download for pLHE step only in pLHE workflow

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs
To use with
https://github.com/cms-sw/cmssw-wm-tools/pull/7

#### External dependencies / deployment changes
No.